### PR TITLE
Small fix and usage conveniences for mixin support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
         hooks:
               - id: isort
                 name: isort (import sorting)
+                additional_dependencies: [toml]
       - repo: https://gitlab.com/pycqa/flake8
         rev: 3.8.3
         hooks:

--- a/README.md
+++ b/README.md
@@ -419,8 +419,8 @@ The timely-beliefs library comes with database-backed classes for the three main
 
 You can let sqlalchemy create the tables in your database session and start using the DB classes (or subclasses, see below) and program code without much work by yourself. The database session is under your control - where or how you get it, depends on the context you're working in. Here is an example how to set up a session and also have sqlachemy create the tables:
 
-    from timely_beliefs.db_base import Base as TBBase
     from sqlalchemy.orm import sessionmaker
+    from timely_beliefs.db_base import Base as TBBase
 
     SessionClass = sessionmaker()
     session = None
@@ -481,8 +481,8 @@ Now you can add objects to your database and query them:
 Adding fields should be most interesting for sensors and maybe belief sources.
 Below is an example, for the case of a db-backed case, where we wanted a sensor to have a location. We added three attributes, `latitude`, `longitude` and `location_name`:
 
-    from timely_beliefs import DBSensor
     from sqlalchemy import Column, Float, String
+    from timely_beliefs import DBSensor
 
 
     class DBLocatedSensor(DBSensor):
@@ -510,8 +510,7 @@ Changing the table name is more tricky. Here is a class where we do that. This o
     from sqlalchemy import Column, Float, ForeignKey
     from sqlalchemy.orm import backref, relationship
     from sqlalchemy.ext.declarative import declared_attr
-    
-    from timely_beliefs.beliefs.classes import TimedBeliefDBMixin
+    from timely_beliefs import TimedBeliefDBMixin
 
 
     class JoyfulBeliefInCustomTable(Base, TimedBeliefDBMixin):

--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ Changing the table name is more tricky. Here is a class where we do that. This o
         def __init__(self, sensor, source, happiness: float = None, **kwargs):
             self.happiness = happiness
             TimedBeliefDBMixin.__init__(self, sensor, source, **kwargs)
+            Base.__init__(self)
 
 
 Note that we don say where the sqlalchemy `Base` comes from here. This is the one from your project. If you create tables from timely_belief's Base (see above) as well, you end up with more tables that you probably want to use. Which is not a blocker, but for cleanliness you might want to get all tables from timely beliefś base or define all Table implementations yourself, such as with `JoyfulBeliefInCustomTable` above.

--- a/timely_beliefs/__init__.py
+++ b/timely_beliefs/__init__.py
@@ -1,7 +1,11 @@
 # flake8: noqa
 
 from timely_beliefs.sensors.classes import DBSensor, Sensor, SensorDBMixin  # isort:skip
-from timely_beliefs.sources.classes import BeliefSource, BeliefSourceDBMixin, DBBeliefSource  # isort:skip
+from timely_beliefs.sources.classes import (  # isort:skip
+    BeliefSource,
+    BeliefSourceDBMixin,
+    DBBeliefSource,
+)
 from timely_beliefs.beliefs.classes import (
     BeliefsDataFrame,
     BeliefsSeries,

--- a/timely_beliefs/__init__.py
+++ b/timely_beliefs/__init__.py
@@ -1,12 +1,13 @@
 # flake8: noqa
 
-from timely_beliefs.sensors.classes import DBSensor, Sensor  # isort:skip
-from timely_beliefs.sources.classes import BeliefSource, DBBeliefSource  # isort:skip
+from timely_beliefs.sensors.classes import DBSensor, Sensor, SensorDBMixin  # isort:skip
+from timely_beliefs.sources.classes import BeliefSource, BeliefSourceDBMixin, DBBeliefSource  # isort:skip
 from timely_beliefs.beliefs.classes import (
     BeliefsDataFrame,
     BeliefsSeries,
     DBTimedBelief,
     TimedBelief,
+    TimedBeliefDBMixin,
 )
 from timely_beliefs.beliefs.utils import load_time_series, read_csv
 from timely_beliefs.examples import beliefs_data_frames

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -53,35 +53,47 @@ class TimedBelief(object):
         sensor: Sensor,
         source: Union[BeliefSource, str, int],
         value: float,
-        **kwargs
+        cumulative_probability: Optional[float] = None,
+        cp: Optional[float] = None,
+        sigma: Optional[float] = None,
+        event_start: Optional[datetime] = None,
+        event_time: Optional[datetime] = None,
+        belief_horizon: Optional[timedelta] = None,
+        belief_time: Optional[datetime] = None,
     ):
         self.sensor = sensor
         self.source = source_utils.ensure_source_exists(source)
         self.event_value = value
 
-        if "cumulative_probability" in kwargs:
-            self.cumulative_probability = kwargs["cumulative_probability"]
-        elif "cp" in kwargs:
-            self.cumulative_probability = kwargs["cp"]
-        elif "sigma" in kwargs:
-            self.cumulative_probability = (
-                1 / 2 + (math.erf(kwargs["sigma"] / 2 ** 0.5)) / 2
-            )
+        if [cumulative_probability, cp, sigma].count(None) not in (2, 3):
+            raise ValueError("Must specify either cumulative_probability, cp, sigma or none of them (0.5 is the default value).")
+        if cumulative_probability is not None:
+            self.cumulative_probability = cumulative_probability
+        elif cp is not None:
+            self.cumulative_probability = cp
+        elif sigma is not None:
+            self.cumulative_probability = 1 / 2 + (math.erf(sigma / 2 ** 0.5)) / 2
         else:
             self.cumulative_probability = 0.5
-        if "event_start" in kwargs:
-            self.event_start = tb_utils.enforce_tz(kwargs["event_start"], "event_start")
-        elif "event_time" in kwargs:
+
+        if [event_start, event_time].count(None) != 1:
+            raise ValueError("Must specify either an event_start or an event_time.")
+        elif event_start is not None:
+            self.event_start = tb_utils.enforce_tz(event_start, "event_start")
+        elif event_time is not None:
             if self.sensor.event_resolution != timedelta():
                 raise KeyError(
                     "Sensor has a non-zero resolution, so it doesn't measure instantaneous events. "
                     "Use event_start instead of event_time."
                 )
-            self.event_start = tb_utils.enforce_tz(kwargs["event_time"], "event_time")
-        if "belief_horizon" in kwargs:
-            self.belief_horizon = kwargs["belief_horizon"]
-        elif "belief_time" in kwargs:
-            belief_time = tb_utils.enforce_tz(kwargs["belief_time"], "belief_time")
+            self.event_start = tb_utils.enforce_tz(event_time, "event_time")
+
+        if [belief_horizon, belief_time].count(None) != 1:
+            raise ValueError("Must specify either a belief_horizon or a belief_time.")
+        elif belief_horizon is not None:
+            self.belief_horizon = belief_horizon
+        elif belief_time is not None:
+            belief_time = tb_utils.enforce_tz(belief_time, "belief_time")
             self.belief_horizon = (
                 self.sensor.knowledge_time(self.event_start, self.event_resolution)
                 - belief_time
@@ -162,11 +174,34 @@ class TimedBeliefDBMixin(TimedBelief):
     def source_id(cls):
         return Column(Integer, ForeignKey("belief_source.id"), primary_key=True)
 
-    def __init__(self, sensor, source, value: float, **kwargs):  # TODO: type hinting?
+    def __init__(
+        self,
+        sensor: DBSensor,
+        source: DBBeliefSource,
+        value: float,
+        cumulative_probability: Optional[float] = None,
+        cp: Optional[float] = None,
+        sigma: Optional[float] = None,
+        event_start: Optional[datetime] = None,
+        event_time: Optional[datetime] = None,
+        belief_horizon: Optional[timedelta] = None,
+        belief_time: Optional[datetime] = None,
+    ):
         self.sensor_id = sensor.id
         self.source_id = source.id
-        TimedBelief.__init__(self, sensor=sensor, source=source, value=value, **kwargs)
-        Base.__init__(self)
+        TimedBelief.__init__(
+            self,
+            sensor=sensor,
+            source=source,
+            value=value,
+            cumulative_probability=cumulative_probability,
+            cp=cp,
+            sigma=sigma,
+            event_start=event_start,
+            event_time=event_time,
+            belief_horizon=belief_horizon,
+            belief_time=belief_time,
+        )
 
     @classmethod
     def query(
@@ -282,7 +317,7 @@ class TimedBeliefDBMixin(TimedBelief):
 class DBTimedBelief(Base, TimedBeliefDBMixin):
     """Database representation of TimedBelief.
     We get fields from the Mixin and configure sensor and source relationships.
-    We are not sure why the relationshps cannot live in the Mixin as declared attributes,
+    We are not sure why the relationships cannot live in the Mixin as declared attributes,
     but they have to be here (thus other custom implementations need to include them, as well).
     """
 
@@ -302,9 +337,31 @@ class DBTimedBelief(Base, TimedBeliefDBMixin):
     )
 
     def __init__(
-        self, sensor: DBSensor, source: DBBeliefSource, value: float, **kwargs
+        self,
+        sensor: DBSensor,
+        source: DBBeliefSource,
+        value: float,
+        cumulative_probability: Optional[float] = None,
+        cp: Optional[float] = None,
+        sigma: Optional[float] = None,
+        event_start: Optional[datetime] = None,
+        event_time: Optional[datetime] = None,
+        belief_horizon: Optional[timedelta] = None,
+        belief_time: Optional[datetime] = None,
     ):
-        TimedBeliefDBMixin.__init__(self, sensor, source, value, **kwargs)
+        TimedBeliefDBMixin.__init__(
+            self,
+            sensor,
+            source,
+            value,
+            cumulative_probability,
+            cp,
+            sigma,
+            event_start,
+            event_time,
+            belief_horizon,
+            belief_time,
+        )
         Base.__init__(self)
 
 

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -66,7 +66,9 @@ class TimedBelief(object):
         self.event_value = value
 
         if [cumulative_probability, cp, sigma].count(None) not in (2, 3):
-            raise ValueError("Must specify either cumulative_probability, cp, sigma or none of them (0.5 is the default value).")
+            raise ValueError(
+                "Must specify either cumulative_probability, cp, sigma or none of them (0.5 is the default value)."
+            )
         if cumulative_probability is not None:
             self.cumulative_probability = cumulative_probability
         elif cp is not None:
@@ -454,7 +456,7 @@ class BeliefsDataFrame(pd.DataFrame):
                 object.__setattr__(self, name, getattr(other, name, None))
         return self
 
-    def __init__(
+    def __init__(  # noqa: C901
         self, *args, **kwargs
     ):  # noqa: C901 todo: refactor, e.g. by detecting initialization method
         """Initialise a multi-index DataFrame with beliefs about a unique sensor."""

--- a/timely_beliefs/beliefs/probabilistic_utils.py
+++ b/timely_beliefs/beliefs/probabilistic_utils.py
@@ -160,9 +160,7 @@ def multivariate_marginal_to_univariate_joint_cdf(  # noqa: C901
     """
 
     dim = len(marginal_cdfs_p)
-    n_outcomes = (
-        99
-    )  # Todo: refactor to avoid having to set this above our threshold for computing exact probabilities
+    n_outcomes = 99  # Todo: refactor to avoid having to set this above our threshold for computing exact probabilities
 
     # Set up marginal distributions
     empirical_method_possible = True

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -176,9 +176,7 @@ def align_belief_times(
                 ps = previous_slice_with_existing_belief_time.reset_index()
                 ps[
                     "belief_time"
-                ] = (
-                    ubt
-                )  # Update belief time to reflect propagation of beliefs over time
+                ] = ubt  # Update belief time to reflect propagation of beliefs over time
                 data.extend(ps.values.tolist())
             else:
                 data.append([event_start, ubt, source, np.nan, np.nan])

--- a/timely_beliefs/sensors/classes.py
+++ b/timely_beliefs/sensors/classes.py
@@ -5,7 +5,6 @@ from sqlalchemy import JSON, Column, Integer, Interval, String
 from sqlalchemy.ext.hybrid import hybrid_method
 
 from timely_beliefs.db_base import Base
-from timely_beliefs.utils import enforce_tz
 from timely_beliefs.sensors.func_store.knowledge_horizons import (
     determine_ex_ante_knowledge_horizon,
     determine_ex_post_knowledge_horizon,

--- a/timely_beliefs/sensors/utils.py
+++ b/timely_beliefs/sensors/utils.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from inspect import getmembers, isfunction, getfullargspec
+from inspect import getfullargspec, getmembers, isfunction
 from typing import Optional, Tuple, Union
 
 from isodate import (

--- a/timely_beliefs/tests/test_db_subclassing.py
+++ b/timely_beliefs/tests/test_db_subclassing.py
@@ -82,9 +82,20 @@ class JoyfulBeliefInCustomTable(Base, TimedBeliefDBMixin):
         "RatedSourceInCustomTable", backref=backref("beliefs", lazy=True)
     )
 
-    def __init__(self, sensor, source, happiness: float = None, **kwargs):
+    def __init__(
+        self,
+        sensor: DBSensor,
+        source: DBBeliefSource,
+        happiness: float = None,
+        **kwargs
+    ):
         self.happiness = happiness
         TimedBeliefDBMixin.__init__(self, sensor, source, **kwargs)
+        [
+            kwargs.pop(key, None)
+            for key in TimedBeliefDBMixin.__init__.__code__.co_varnames
+        ]
+        Base.__init__(self, **kwargs)
 
 
 def test_custom_source_and_beliefs_with_mixin(db):

--- a/timely_beliefs/tests/test_db_subclassing.py
+++ b/timely_beliefs/tests/test_db_subclassing.py
@@ -94,7 +94,7 @@ class JoyfulBeliefInCustomTable(Base, TimedBeliefDBMixin):
         [
             kwargs.pop(key, None)
             for key in TimedBeliefDBMixin.__init__.__code__.co_varnames
-        ]
+        ]  # take out any kwargs used by the mixin, and pass on any remaining kwargs to the next super class.
         Base.__init__(self, **kwargs)
 
 

--- a/timely_beliefs/visualization/utils.py
+++ b/timely_beliefs/visualization/utils.py
@@ -305,9 +305,7 @@ def align_belief_horizons(
             if previous_slice_with_existing_belief_horizon is not None:
                 previous_slice_with_existing_belief_horizon[
                     "belief_horizon"
-                ] = (
-                    ubh
-                )  # Update belief horizon to reflect propagation of beliefs over time
+                ] = ubh  # Update belief horizon to reflect propagation of beliefs over time
                 data.extend(previous_slice_with_existing_belief_horizon.values.tolist())
         else:
             # If already present, copy the row (may be multiple rows in case of a probabilistic belief)


### PR DESCRIPTION
Explicit parameters preferred over kwargs.
Don't init Base in mixin.
Simplify import of mixins.