### PR TITLE
Inherit metadata when resampling and grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ This will create an interactive Vega-Lite chart like the one in the screenshot a
 
 ## Development
 
-We welcome other contributions to timely_beliefs.
+The `timely_beliefs` package runs on `pandas>=1.1.5`.
+Contact us if you need support for older versions.
+We welcome other contributions to `timely_beliefs`.
 
 [See our developer docs for details.](dev/dev.md)

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ setup(
         "uncertainty",
         "lineage",
     ],
-    version="0.1.3",
+    version="1.0.0",
     install_requires=[
         "pytz",
-        "pandas>=0.24,<1.1",  # test_groupby_preserves_metadata fails on 1.1
+        "pandas>=1.1.5",
         "numpy",
         "pyerf",
         "SQLAlchemy",

--- a/timely_beliefs/beliefs/__init__.py
+++ b/timely_beliefs/beliefs/__init__.py
@@ -8,6 +8,7 @@ Below, we register customer accessors.
 from datetime import datetime, timedelta
 from typing import List
 
+import pandas as pd
 from pandas.api.extensions import register_dataframe_accessor
 
 
@@ -120,7 +121,9 @@ class BeliefsAccessor(object):
     @property
     def number_of_probabilistic_beliefs(self) -> int:
         """Return the number of beliefs in the BeliefsDataFrame that are probabilistic (more than 1 unique value)."""
-        df = self._obj.for_each_belief(df=self._obj).nunique(dropna=True)
+        df = self._obj.for_each_belief(
+            df=self._obj, fnc=pd.DataFrame.nunique, dropna=True
+        )
         return len(df[df > 1].max(axis=1).dropna())
 
     @property

--- a/timely_beliefs/beliefs/__init__.py
+++ b/timely_beliefs/beliefs/__init__.py
@@ -105,7 +105,7 @@ class BeliefsAccessor(object):
     def number_of_beliefs(self) -> int:
         """Return the total number of beliefs in the BeliefsDataFrame, including both deterministic beliefs (which
         require a single row) and probabilistic beliefs (which require multiple rows)."""
-        return len(self._obj.for_each_belief(df=self._obj))
+        return len(self._obj.for_each_belief())
 
     @property
     def sources(self) -> List[int]:
@@ -121,9 +121,7 @@ class BeliefsAccessor(object):
     @property
     def number_of_probabilistic_beliefs(self) -> int:
         """Return the number of beliefs in the BeliefsDataFrame that are probabilistic (more than 1 unique value)."""
-        df = self._obj.for_each_belief(
-            df=self._obj, fnc=pd.DataFrame.nunique, dropna=True
-        )
+        df = self._obj.for_each_belief(fnc=pd.DataFrame.nunique, dropna=True)
         return len(df[df > 1].max(axis=1).dropna())
 
     @property

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -1457,7 +1457,7 @@ def set_columns_and_indices_for_empty_frame(df, columns, indices, default_types)
         elif default_types[col] in (int, float):
             df[col] = pd.to_numeric(df[col])
 
-    df.set_index(indices, inplace=True)
+    df.set_index(indices, inplace=True)  # todo: pandas GH30517
 
 
 def assign_sensor_and_event_resolution(df, sensor, event_resolution):

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -1032,7 +1032,7 @@ class BeliefsDataFrame(pd.DataFrame):
                 # upsample
                 new_index = pd.date_range(
                     start=df.index[0],
-                    periods=len(df) * self.event_resolution // event_resolution,
+                    periods=len(df) * (self.event_resolution // event_resolution),
                     freq=event_resolution,
                     name="event_start",
                 )

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -1021,7 +1021,9 @@ class BeliefsDataFrame(pd.DataFrame):
                     else "min",  # keep only most recent belief
                     "cumulative_probability": "prod",  # assume independent variables
                 }
-                df = resample_beliefs_data_frame(df, event_resolution, column_functions)
+                df = downsample_beliefs_data_frame(
+                    df, event_resolution, column_functions
+                )
                 df.event_resolution = event_resolution
             else:
                 # upsample
@@ -1472,7 +1474,7 @@ def assign_sensor_and_event_resolution(df, sensor, event_resolution):
     )
 
 
-def resample_beliefs_data_frame(
+def downsample_beliefs_data_frame(
     df: BeliefsDataFrame, event_resolution: timedelta, col_att_dict: Dict[str, str]
 ) -> BeliefsDataFrame:
     """Because df.resample().agg() doesn't behave nicely for subclassed DataFrames,

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -375,7 +375,11 @@ class BeliefsSeries(pd.Series):
 
     @property
     def _constructor(self):
-        return BeliefsSeries
+        def f(*args, **kwargs):
+            """ Call __finalize__() after construction to inherit metadata. """
+            return BeliefsSeries(*args, **kwargs).__finalize__(self, method="inherit")
+
+        return f
 
     @property
     def _constructor_expanddim(self):
@@ -436,7 +440,13 @@ class BeliefsDataFrame(pd.DataFrame):
 
     @property
     def _constructor(self):
-        return BeliefsDataFrame
+        def f(*args, **kwargs):
+            """ Call __finalize__() after construction to inherit metadata. """
+            return BeliefsDataFrame(*args, **kwargs).__finalize__(
+                self, method="inherit"
+            )
+
+        return f
 
     @property
     def _constructor_sliced(self):
@@ -1017,12 +1027,7 @@ class BeliefsDataFrame(pd.DataFrame):
                         "cumulative_probability": "prod",  # assume independent variables
                     }
                 )
-                # make a new BeliefsDataFrame, because agg() doesn't behave nicely for subclassed DataFrames
-                df = BeliefsDataFrame(
-                    df.reset_index(),
-                    sensor=self.sensor,
-                    event_resolution=event_resolution,
-                )
+                df.event_resolution = event_resolution
             else:
                 # upsample
                 new_index = pd.date_range(

--- a/timely_beliefs/sources/classes.py
+++ b/timely_beliefs/sources/classes.py
@@ -1,3 +1,4 @@
+from functools import total_ordering
 from typing import Union
 
 from sqlalchemy import Column, Integer, String
@@ -5,10 +6,11 @@ from sqlalchemy import Column, Integer, String
 from timely_beliefs.db_base import Base
 
 
+@total_ordering
 class BeliefSource(object):
 
     """
-    A belief source is any data-creating entitiy such as a user, a ML model or a script.
+    A belief source is any data-creating entity such as a user, a ML model or a script.
     """
 
     name: str

--- a/timely_beliefs/tests/test_belief_io.py
+++ b/timely_beliefs/tests/test_belief_io.py
@@ -444,7 +444,7 @@ def test_groupby_retains_metadata():
 
     Succeeds with pandas==1.0.0
     Fails with pandas==1.1.0
-    Should be fixed with https://github.com/pandas-dev/pandas/pull/37461
+    Fixed with pandas==1.1.5
     """
     df = example_df
     metadata = {md: getattr(example_df, md) for md in METADATA}

--- a/timely_beliefs/tests/test_belief_io.py
+++ b/timely_beliefs/tests/test_belief_io.py
@@ -553,6 +553,8 @@ def test_groupby_retains_subclass_attribute(att, args):
     """Checks on metadata propagation for subclassed DataFrames under groupby operations.
 
     Commented-out parameter combinations fail with pandas==1.1.5
+    The relevant issue has to do with calling finalize after operations:
+    see https://github.com/pandas-dev/pandas/issues/28283
     """
 
     METADATA = ["a"]

--- a/timely_beliefs/tests/test_belief_io.py
+++ b/timely_beliefs/tests/test_belief_io.py
@@ -7,8 +7,8 @@ import pytest
 import pytz
 
 import timely_beliefs as tb
-from timely_beliefs.beliefs.classes import METADATA
 from timely_beliefs.examples import example_df
+from timely_beliefs.tests.utils import assert_metadata_is_retained
 
 
 @pytest.fixture(scope="module")
@@ -360,21 +360,16 @@ def test_converting_between_data_frame_and_series_retains_metadata():
     Test whether expanding dimensions of a BeliefsSeries into a BeliefsDataFrame retains the metadata.
     """
     df = example_df
-    metadata = {md: getattr(example_df, md) for md in METADATA}
     series = df["event_value"]
-    for md in metadata:
-        assert getattr(series, md) == metadata[md]
+    assert_metadata_is_retained(series, original_df=example_df, is_series=True)
     df = series.to_frame()
-    for md in metadata:
-        assert getattr(df, md) == metadata[md]
+    assert_metadata_is_retained(df, original_df=example_df)
 
 
 def test_dropping_index_levels_retains_metadata():
     df = example_df.copy()
-    metadata = {md: getattr(example_df, md) for md in METADATA}
     df.index = df.index.get_level_values("event_start")  # drop all other index levels
-    for md in metadata:
-        assert getattr(df, md) == metadata[md]
+    assert_metadata_is_retained(df, original_df=example_df)
 
 
 @pytest.mark.parametrize("drop_level", [True, False])
@@ -383,12 +378,9 @@ def test_slicing_retains_metadata(drop_level):
     Test whether slicing the index of a BeliefsDataFrame retains the metadata.
     """
     df = example_df
-    metadata = {md: getattr(example_df, md) for md in METADATA}
     df = df.xs("2000-01-03 10:00:00+00:00", level="event_start", drop_level=drop_level)
     print(df)
-    assert isinstance(df, tb.BeliefsDataFrame)
-    for md in metadata:
-        assert getattr(df, md) == metadata[md]
+    assert_metadata_is_retained(df, original_df=example_df)
 
 
 @pytest.mark.parametrize("resolution", [timedelta(minutes=30), timedelta(hours=2)])
@@ -400,15 +392,13 @@ def test_mean_resampling_retains_metadata(resolution):
     Succeeds with pandas==1.1.0
     """
     df = example_df
-    metadata = {md: getattr(example_df, md) for md in METADATA}
     df = df.resample(resolution, level="event_start").mean()
     print(df)
-    assert isinstance(df, tb.BeliefsDataFrame)
-    for md in metadata:
-        # if md == "event_resolution":
-        #     assert df.event_resolution == resolution
-        # else:  # todo: the event_resolution metadata is only updated when resampling using df.resample_events(). A reason to override the original resample method, or otherwise something to document.
-        assert getattr(df, md) == metadata[md]
+    assert_metadata_is_retained(
+        df,
+        original_df=example_df,
+        event_resolution=example_df.event_resolution,
+    )  # todo: the event_resolution metadata is only updated when resampling using df.resample_events(). A reason to override the original resample method, or otherwise something to document.
 
 
 @pytest.mark.parametrize("resolution", [timedelta(minutes=30), timedelta(hours=2)])
@@ -419,7 +409,6 @@ def _test_agg_resampling_retains_metadata(resolution):
     Fails with pandas==1.1.5
     """
     df = example_df
-    metadata = {md: getattr(example_df, md) for md in METADATA}
     df = df.reset_index(level=["belief_time", "source", "cumulative_probability"])
     df = df.resample(resolution).agg(
         {
@@ -431,12 +420,11 @@ def _test_agg_resampling_retains_metadata(resolution):
     )
     df = df.set_index(["belief_time", "source", "cumulative_probability"], append=True)
     print(df)
-    assert isinstance(df, tb.BeliefsDataFrame)
-    for md in metadata:
-        # if md == "event_resolution":
-        #     assert df.event_resolution == resolution
-        # else:  # todo: the event_resolution metadata is only updated when resampling using df.resample_events(). A reason to override the original resample method, or otherwise something to document.
-        assert getattr(df, md) == metadata[md]
+    assert_metadata_is_retained(
+        df,
+        original_df=example_df,
+        event_resolution=example_df.event_resolution,
+    )  # todo: the event_resolution metadata is only updated when resampling using df.resample_events(). A reason to override the original resample method, or otherwise something to document.
 
 
 def test_groupby_retains_metadata():
@@ -447,19 +435,14 @@ def test_groupby_retains_metadata():
     Fixed with pandas==1.1.5
     """
     df = example_df
-    metadata = {md: getattr(example_df, md) for md in METADATA}
 
     def assert_function(x):
         print(x)
-        assert isinstance(x, tb.BeliefsDataFrame)
-        for md in metadata:
-            assert getattr(x, md) == metadata[md]
+        assert_metadata_is_retained(x, original_df=example_df)
         return x
 
     df = df.groupby(level="event_start").apply(lambda x: assert_function(x))
-    assert isinstance(df, tb.BeliefsDataFrame)
-    for md in metadata:
-        assert getattr(df, md) == metadata[md]
+    assert_metadata_is_retained(df, original_df=example_df)
 
 
 def test_copy_series_retains_name_and_metadata():
@@ -589,3 +572,19 @@ def test_groupby_retains_subclass_attribute(att, args):
     df2 = getattr(df.groupby("x"), att)(*args)
     print(df2)
     assert df2.a == "b"
+
+
+@pytest.mark.parametrize("constant", [1, -1, 3.14, timedelta(hours=1), ["TiledString"]])
+def test_multiplication_with_constant_retains_metadata(constant):
+    """ Check whether the metadata is still there after multiplication. """
+    # GH 35
+    df = example_df * constant
+    assert_metadata_is_retained(df, original_df=example_df)
+
+    # Also check suggested workarounds from GH 35
+    if constant == -1:
+        df = -example_df
+        assert_metadata_is_retained(df, original_df=example_df)
+
+        df = example_df.abs()
+        assert_metadata_is_retained(df, original_df=example_df)

--- a/timely_beliefs/tests/test_belief_io.py
+++ b/timely_beliefs/tests/test_belief_io.py
@@ -411,11 +411,11 @@ def test_agg_resampling_retains_metadata(resolution):
 
 
 def test_groupby_retains_metadata():
-    """ Test whether grouping by index level retains the metadata.
+    """Test whether grouping by index level retains the metadata.
 
     Succeeds with pandas==1.0.0
     Fails with pandas==1.1.0
-    Should be fixed with https://github.com/pandas-dev/pandas/pull/35688
+    Should be fixed with https://github.com/pandas-dev/pandas/pull/37461
     """
     df = example_df
     metadata = {md: getattr(example_df, md) for md in METADATA}
@@ -477,3 +477,13 @@ def test_init_from_beliefs_series():
         bdf, df_copy
     )  # new bdf retains altered column of original bdf
     pd.testing.assert_series_equal(s, s_copy)  # input BeliefsSeries was not altered
+
+
+def test_groupby_retains_attribute():
+    df = pd.DataFrame([[1, 2], [3, 4]], columns=["x", "y"])
+    df.a = "b"
+    assert df.a == "b"
+    df = df.groupby("x").apply(lambda x: x)
+    assert df.a == "b"
+    df = df.groupby("x").sum()
+    assert df.a == "b"

--- a/timely_beliefs/tests/utils.py
+++ b/timely_beliefs/tests/utils.py
@@ -1,7 +1,37 @@
-from typing import Union
+from datetime import timedelta
+from typing import Optional, Union
 
 import numpy as np
+
+import timely_beliefs as tb
+from timely_beliefs.beliefs.classes import METADATA
 
 
 def equal_lists(list_a: Union[list, np.ndarray], list_b: Union[list, np.ndarray]):
     return all(np.isclose(a, b) for a, b in zip(list_a, list_b))
+
+
+def assert_metadata_is_retained(
+    result_df: Union[tb.BeliefsDataFrame, tb.BeliefsSeries],
+    original_df: tb.BeliefsDataFrame,
+    is_series: bool = False,
+    event_resolution: Optional[timedelta] = None,
+):
+    """Fail if result_df is not a BeliefsDataFrame with the same metadata as the original BeliefsDataFrame.
+
+    Can also be used to check for a BeliefsSeries (using is_series=True).
+
+    :param result_df: BeliefsDataFrame or BeliefsSeries to be checked for metadata propagation
+    :param original_df: BeliefsDataFrame containing the original metadata
+    :param is_series: if True, we check that the result is a BeliefsSeries rather than a BeliefsDataFrame
+    :param event_resolution: optional timedelta in case we expect a different event_resolution than the original
+    """
+    metadata = {md: getattr(original_df, md) for md in METADATA}
+    assert isinstance(
+        result_df, tb.BeliefsDataFrame if not is_series else tb.BeliefsSeries
+    )
+    for md in metadata:
+        if md == "event_resolution" and event_resolution is not None:
+            assert result_df.event_resolution == event_resolution
+        else:
+            assert getattr(result_df, md) == metadata[md]

--- a/timely_beliefs/visualization/utils.py
+++ b/timely_beliefs/visualization/utils.py
@@ -250,20 +250,18 @@ def prepare_df_for_plotting(
         df["lower_value"] = df["event_value"]
     else:
         df_ci0 = (
-            df.for_each_belief(get_nth_percentile_belief, n=(1 - ci) * 100 / 2, df=df)
+            df.for_each_belief(get_nth_percentile_belief, n=(1 - ci) * 100 / 2)
             .rename(columns={"event_value": "lower_value"})
             .droplevel("cumulative_probability")
             .drop("belief_horizon", axis=1)
         )
         df_exp = (
-            df.for_each_belief(get_nth_percentile_belief, n=50, df=df)
+            df.for_each_belief(get_nth_percentile_belief, n=50)
             .rename(columns={"event_value": "expected_value"})
             .droplevel("cumulative_probability")
         )
         df_ci1 = (
-            df.for_each_belief(
-                get_nth_percentile_belief, n=100 - (1 - ci) * 100 / 2, df=df
-            )
+            df.for_each_belief(get_nth_percentile_belief, n=100 - (1 - ci) * 100 / 2)
             .rename(columns={"event_value": "upper_value"})
             .droplevel("cumulative_probability")
             .drop("belief_horizon", axis=1)

--- a/timely_beliefs/visualization/utils.py
+++ b/timely_beliefs/visualization/utils.py
@@ -40,6 +40,7 @@ def plot(
 
     # Set up data source
     bdf = bdf.copy()
+    bdf["event_value"] = bdf["event_value"].astype(float)
     sensor_name = bdf.sensor.name
     sensor_unit = bdf.sensor.unit if bdf.sensor.unit != "" else "a.u."  # arbitrary unit
     plottable_df, belief_horizon_unit = prepare_df_for_plotting(


### PR DESCRIPTION
Call finalize in all constructors to inherit metadata.
Prepare tests for upcoming pandas==1.1.1 functionality: inherit metadata when resampling and grouping.