### PR TITLE
Issue 35 metadata lost on multiplication

### DIFF
--- a/timely_beliefs/tests/test_belief_io.py
+++ b/timely_beliefs/tests/test_belief_io.py
@@ -570,3 +570,19 @@ def test_groupby_retains_subclass_attribute(att, args):
     df2 = getattr(df.groupby("x"), att)(*args)
     print(df2)
     assert df2.a == "b"
+
+
+@pytest.mark.parametrize("constant", [1, -1, 3.14, timedelta(hours=1), ["TiledString"]])
+def test_multiplication_with_constant_retains_metadata(constant):
+    """ Check whether the metadata is still there after multiplication. """
+    # GH 35
+    df = example_df * constant
+    assert_metadata_is_retained(df, original_df=example_df)
+
+    # Also check suggested workarounds from GH 35
+    if constant == -1:
+        df = -example_df
+        assert_metadata_is_retained(df, original_df=example_df)
+
+        df = example_df.abs()
+        assert_metadata_is_retained(df, original_df=example_df)

--- a/timely_beliefs/tests/utils.py
+++ b/timely_beliefs/tests/utils.py
@@ -1,7 +1,37 @@
-from typing import Union
+from datetime import timedelta
+from typing import Optional, Union
 
 import numpy as np
+
+import timely_beliefs as tb
+from timely_beliefs.beliefs.classes import METADATA
 
 
 def equal_lists(list_a: Union[list, np.ndarray], list_b: Union[list, np.ndarray]):
     return all(np.isclose(a, b) for a, b in zip(list_a, list_b))
+
+
+def assert_metadata_is_retained(
+    result_df: Union[tb.BeliefsDataFrame, tb.BeliefsSeries],
+    original_df: tb.BeliefsDataFrame,
+    is_series: bool = False,
+    event_resolution: Optional[timedelta] = None,
+):
+    """Fail if result_df is not a BeliefsDataFrame with the same metadata as the original BeliefsDataFrame.
+
+    Can also be used to check for a BeliefsSeries (using is_series=True).
+
+    :param result_df: BeliefsDataFrame or BeliefsSeries to be checked for metadata propagation
+    :param original_df: BeliefsDataFrame containing the original metadata
+    :param is_series: if True, we check that the result is a BeliefsSeries rather than a BeliefsDataFrame
+    :param event_resolution: optional timedelta in case we expect a different event_resolution than the original
+    """
+    metadata = {md: getattr(original_df, md) for md in METADATA}
+    assert isinstance(
+        result_df, tb.BeliefsDataFrame if not is_series else tb.BeliefsSeries
+    )
+    for md in metadata:
+        if md == "event_resolution" and event_resolution is not None:
+            assert result_df.event_resolution == event_resolution
+        else:
+            assert getattr(result_df, md) == metadata[md]


### PR DESCRIPTION
This PR adds no additional logic, only a test to check whether Issue #35 is successfully resolved (plus some refactoring of test util functions). Note that this is a merge into resample-while-keeping-metadata, and that branch (with PR #23) actually contains the logic that resolves this issue (as a side effect, because I was actually addressing deeper issues there: #22 and #26).