### PR TITLE
More user friendly conversions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "uncertainty",
         "lineage",
     ],
-    version="1.0.0",
+    version="1.0.1",
     install_requires=[
         "pytz",
         "pandas>=1.1.5",

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -706,7 +706,7 @@ class BeliefsDataFrame(pd.DataFrame):
     @property
     def knowledge_times(self) -> pd.DatetimeIndex:
         return pd.DatetimeIndex(
-            self.event_starts.to_series(name="knowledge_time", keep_tz=True).apply(
+            self.event_starts.to_series(name="knowledge_time").apply(
                 lambda event_start: self.sensor.knowledge_time(
                     event_start, self.event_resolution
                 )
@@ -716,7 +716,7 @@ class BeliefsDataFrame(pd.DataFrame):
     @property
     def knowledge_horizons(self) -> pd.TimedeltaIndex:
         return pd.TimedeltaIndex(
-            self.event_starts.to_series(name="knowledge_horizon", keep_tz=True).apply(
+            self.event_starts.to_series(name="knowledge_horizon").apply(
                 lambda event_start: self.sensor.knowledge_horizon(
                     event_start, self.event_resolution
                 )
@@ -744,7 +744,7 @@ class BeliefsDataFrame(pd.DataFrame):
     @property
     def event_ends(self) -> pd.DatetimeIndex:
         return pd.DatetimeIndex(
-            self.event_starts.to_series(name="event_end", keep_tz=True).apply(
+            self.event_starts.to_series(name="event_end").apply(
                 lambda event_start: event_start + self.event_resolution
             )
         )

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -892,7 +892,7 @@ class BeliefsDataFrame(pd.DataFrame):
         >>> # Select the latest beliefs formed from June 1st to June 6th (up to June 6th 0:00 AM)
         >>> df.fixed_viewpoint(belief_time_window=(datetime(2018, 6, 1, tzinfo=utc), datetime(2018, 6, 6, tzinfo=utc)))
 
-        :param belief_time: datetime indicating the belief should be formed at least before this time
+        :param belief_time: datetime indicating the belief should be formed at least before or at this time
         :param belief_time_window: optional tuple specifying a time window within which beliefs should have been formed
         :param update_belief_times: if True, update the belief time of each belief with the given fixed viewpoint
         """

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -20,17 +20,27 @@ from timely_beliefs.sources import utils as source_utils
 def select_most_recent_belief(
     df: "classes.BeliefsDataFrame",
 ) -> "classes.BeliefsDataFrame":
-    """Drop all but most recent belief."""
+    """Drop all but most recent non-NaN belief."""
     if "belief_horizon" in df.index.names:
-        return df.groupby(level=["event_start", "source"], group_keys=False).apply(
-            lambda x: x.xs(
-                min(x.lineage.belief_horizons), level="belief_horizon", drop_level=False
+        return (
+            df.dropna(axis=0)
+            .groupby(level=["event_start", "source"], group_keys=False)
+            .apply(
+                lambda x: x.xs(
+                    min(x.lineage.belief_horizons),
+                    level="belief_horizon",
+                    drop_level=False,
+                )
             )
         )
     elif "belief_time" in df.index.names:
-        return df.groupby(level=["event_start", "source"], group_keys=False).apply(
-            lambda x: x.xs(
-                max(x.lineage.belief_times), level="belief_time", drop_level=False
+        return (
+            df.dropna(axis=0)
+            .groupby(level=["event_start", "source"], group_keys=False)
+            .apply(
+                lambda x: x.xs(
+                    max(x.lineage.belief_times), level="belief_time", drop_level=False
+                )
             )
         )
     else:

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -445,10 +445,13 @@ def set_reference(
     if return_expected_value is True:
         reference_df = reference_df.for_each_belief(get_expected_belief)
 
+    belief_timing_col = (
+        "belief_time" if "belief_time" in reference_df.index.names else "belief_horizon"
+    )
     reference_df = reference_df.droplevel(
-        ["event_start", "belief_time", "cumulative_probability"]
+        ["event_start", belief_timing_col, "cumulative_probability"]
         if return_expected_value is True
-        else ["event_start", "belief_time"]
+        else ["event_start", belief_timing_col]
     ).rename(columns={"event_value": "reference_value"})
 
     # Set the reference values for each belief

--- a/timely_beliefs/visualization/utils.py
+++ b/timely_beliefs/visualization/utils.py
@@ -229,6 +229,7 @@ def prepare_df_for_plotting(
     - a string representing the time unit for the horizons
     """
     event_resolution = df.event_resolution
+    df = df.convert_index_from_belief_horizon_to_time()
     if show_accuracy is True:
         reference_df = df.groupby(level="event_start").apply(
             lambda x: x.accuracy(reference_source=reference_source, lite_metrics=True)


### PR DESCRIPTION
Mostly reindexing from belief_time to belief_horizon, but also getting rid of future warning and one bug fix where selecting the most recent belief can result in selecting a NaN belief, which isn't the one we want to select.

I still have 1 test (test_crps) to fix.