### PR TITLE
More user friendly initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ The data model is an extended [pandas](https://pandas.pydata.org/) DataFrame tha
 - [When the data was created](timely_beliefs/docs/timing.md/#beliefs-in-physics)
 - [How certain they were](timely_beliefs/docs/confidence.md)
 
+Getting started (or try one of the [other ways to create a BeliefsDataFrame](timely_beliefs/docs/init.md)):
+
+    >>> import timely_beliefs as tb
+    >>> bdf = tb.BeliefsDataFrame([tb.Belief(tb.Sensor("Indoor temperature", "°C"), tb.BeliefSource("Thermometer"), 21, event_time="2000-03-05 11:00Z", belief_horizon="0H")])
+    >>> print(bdf)
+                                                                                            event_value
+    event_start               belief_time               source      cumulative_probability             
+    2000-03-05 11:00:00+00:00 2000-03-05 11:00:00+00:00 Thermometer 0.5                              21
+
 The package contains the following functionality:
 
 - [A model for time series data](#the-data-model), suitable for a notebook or a [database-backed](#database-storage) program (using [sqlalchemy](https://sqlalche.me))
@@ -89,6 +98,7 @@ _For a future release we are considering adding the sensor as another index leve
 to offer out-of-the-box support for aggregating over multiple sensors._
 
 
+- [Read more about how to create a BeliefsDataFrame.](timely_beliefs/docs/init.md)
 - [Read more about how the DataFrame is keeping track of time.](timely_beliefs/docs/timing.md)
 - [Read more about how the DataFrame is keeping track of confidence.](timely_beliefs/docs/confidence.md)
 - [Discover convenient slicing methods (e.g. to show a rolling horizon forecast).](timely_beliefs/docs/slicing.md)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The data model is an extended [pandas](https://pandas.pydata.org/) DataFrame tha
 Getting started (or try one of the [other ways to create a BeliefsDataFrame](timely_beliefs/docs/init.md)):
 
     >>> import timely_beliefs as tb
-    >>> bdf = tb.BeliefsDataFrame([tb.Belief(tb.Sensor("Indoor temperature", "°C"), tb.BeliefSource("Thermometer"), 21, event_time="2000-03-05 11:00Z", belief_horizon="0H")])
+    >>> bdf = tb.BeliefsDataFrame([tb.TimedBelief(tb.Sensor("Indoor temperature", "°C"), tb.BeliefSource("Thermometer"), 21, event_time="2000-03-05 11:00Z", belief_horizon="0H")])
     >>> print(bdf)
                                                                                             event_value
     event_start               belief_time               source      cumulative_probability             

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "uncertainty",
         "lineage",
     ],
-    version="1.0.1",
+    version="1.1.0",
     install_requires=[
         "pytz",
         "pandas>=1.1.5",

--- a/timely_beliefs/__init__.py
+++ b/timely_beliefs/__init__.py
@@ -7,7 +7,6 @@ from timely_beliefs.sources.classes import (  # isort:skip
     DBBeliefSource,
 )
 from timely_beliefs.beliefs.classes import (
-    Belief,
     BeliefsDataFrame,
     BeliefsSeries,
     DBTimedBelief,

--- a/timely_beliefs/__init__.py
+++ b/timely_beliefs/__init__.py
@@ -7,6 +7,7 @@ from timely_beliefs.sources.classes import (  # isort:skip
     DBBeliefSource,
 )
 from timely_beliefs.beliefs.classes import (
+    Belief,
     BeliefsDataFrame,
     BeliefsSeries,
     DBTimedBelief,

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -432,8 +432,7 @@ class BeliefsDataFrame(pd.DataFrame):
         Method 2:   pass a pandas DataFrame with columns ["event_start", "belief_time", "source", "event_value"]
                     - Optional column: "cumulative_probability" (the default is 0.5)
                     - Alternatively, use keyword arguments to replace columns containing unique values for each belief
-        Method 3:   pass a pandas Series with DatetimeIndex and keyword arguments for "source"
-                    - Optional keyword argument: "belief_horizon" (the default is sensor.event_resolution)
+        Method 3:   pass a pandas Series with DatetimeIndex and keyword arguments for "belief_time" or "belief_horizon", and "source"
                     - Alternatively, use the "event_start" keyword argument to ignore the index
 
     In addition to the standard DataFrame constructor arguments,
@@ -1526,3 +1525,6 @@ def downsample_beliefs_data_frame(
         ],
         axis=1,
     ).set_index([belief_timing_col, "source", "cumulative_probability"], append=True)
+
+
+Belief = TimedBelief

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -23,6 +23,8 @@ from timely_beliefs.sources.classes import BeliefSource, DBBeliefSource
 from timely_beliefs.visualization import utils as visualization_utils
 
 METADATA = ["sensor", "event_resolution"]
+DatetimeLike = Union[datetime, str, pd.Timestamp]
+TimedeltaLike = Union[timedelta, str, pd.Timedelta]
 
 
 class TimedBelief(object):
@@ -57,10 +59,10 @@ class TimedBelief(object):
         cumulative_probability: Optional[float] = None,
         cp: Optional[float] = None,
         sigma: Optional[float] = None,
-        event_start: Optional[datetime] = None,
-        event_time: Optional[datetime] = None,
-        belief_horizon: Optional[timedelta] = None,
-        belief_time: Optional[datetime] = None,
+        event_start: Optional[DatetimeLike] = None,
+        event_time: Optional[DatetimeLike] = None,
+        belief_horizon: Optional[TimedeltaLike] = None,
+        belief_time: Optional[DatetimeLike] = None,
     ):
         self.sensor = sensor
         self.source = source_utils.ensure_source_exists(source)
@@ -90,21 +92,21 @@ class TimedBelief(object):
         if [event_start, event_time].count(None) != 1:
             raise ValueError("Must specify either an event_start or an event_time.")
         elif event_start is not None:
-            self.event_start = tb_utils.enforce_tz(event_start, "event_start")
+            self.event_start = tb_utils.parse_datetime_like(event_start, "event_start")
         elif event_time is not None:
             if self.sensor.event_resolution != timedelta():
                 raise KeyError(
                     "Sensor has a non-zero resolution, so it doesn't measure instantaneous events. "
                     "Use event_start instead of event_time."
                 )
-            self.event_start = tb_utils.enforce_tz(event_time, "event_time")
+            self.event_start = tb_utils.parse_datetime_like(event_time, "event_time")
 
         if [belief_horizon, belief_time].count(None) != 1:
             raise ValueError("Must specify either a belief_horizon or a belief_time.")
         elif belief_horizon is not None:
-            self.belief_horizon = belief_horizon
+            self.belief_horizon = tb_utils.parse_timedelta_like(belief_horizon)
         elif belief_time is not None:
-            belief_time = tb_utils.enforce_tz(belief_time, "belief_time")
+            belief_time = tb_utils.parse_datetime_like(belief_time, "belief_time")
             self.belief_horizon = (
                 self.sensor.knowledge_time(self.event_start, self.event_resolution)
                 - belief_time
@@ -193,10 +195,10 @@ class TimedBeliefDBMixin(TimedBelief):
         cumulative_probability: Optional[float] = None,
         cp: Optional[float] = None,
         sigma: Optional[float] = None,
-        event_start: Optional[datetime] = None,
-        event_time: Optional[datetime] = None,
-        belief_horizon: Optional[timedelta] = None,
-        belief_time: Optional[datetime] = None,
+        event_start: Optional[DatetimeLike] = None,
+        event_time: Optional[DatetimeLike] = None,
+        belief_horizon: Optional[TimedeltaLike] = None,
+        belief_time: Optional[DatetimeLike] = None,
     ):
         self.sensor_id = sensor.id
         self.source_id = source.id
@@ -240,13 +242,15 @@ class TimedBeliefDBMixin(TimedBelief):
 
         # Check for timezone-aware datetime input
         if event_before is not None:
-            event_before = tb_utils.enforce_tz(event_before, "event_before")
+            event_before = tb_utils.parse_datetime_like(event_before, "event_before")
         if event_not_before is not None:
-            event_not_before = tb_utils.enforce_tz(event_not_before, "event_not_before")
+            event_not_before = tb_utils.parse_datetime_like(
+                event_not_before, "event_not_before"
+            )
         if belief_before is not None:
-            belief_before = tb_utils.enforce_tz(belief_before, "belief_before")
+            belief_before = tb_utils.parse_datetime_like(belief_before, "belief_before")
         if belief_not_before is not None:
-            belief_not_before = tb_utils.enforce_tz(
+            belief_not_before = tb_utils.parse_datetime_like(
                 belief_not_before, "belief_not_before"
             )
 
@@ -355,10 +359,10 @@ class DBTimedBelief(Base, TimedBeliefDBMixin):
         cumulative_probability: Optional[float] = None,
         cp: Optional[float] = None,
         sigma: Optional[float] = None,
-        event_start: Optional[datetime] = None,
-        event_time: Optional[datetime] = None,
-        belief_horizon: Optional[timedelta] = None,
-        belief_time: Optional[datetime] = None,
+        event_start: Optional[DatetimeLike] = None,
+        event_time: Optional[DatetimeLike] = None,
+        belief_horizon: Optional[TimedeltaLike] = None,
+        belief_time: Optional[DatetimeLike] = None,
     ):
         TimedBeliefDBMixin.__init__(
             self,
@@ -495,13 +499,13 @@ class BeliefsDataFrame(pd.DataFrame):
 
         # Obtain parameters that are specific to our DataFrame subclass
         sensor: Sensor = kwargs.pop("sensor", None)
-        event_resolution: timedelta = kwargs.pop("event_resolution", None)
+        event_resolution: TimedeltaLike = kwargs.pop("event_resolution", None)
         source: Union[BeliefSource, str, int] = kwargs.pop("source", None)
         source: BeliefSource = source_utils.ensure_source_exists(
             source, allow_none=True
         )
-        event_start: datetime = kwargs.pop("event_start", None)
-        belief_time: datetime = kwargs.pop("belief_time", None)
+        event_start: DatetimeLike = kwargs.pop("event_start", None)
+        belief_time: DatetimeLike = kwargs.pop("belief_time", None)
         belief_horizon: datetime = kwargs.pop("belief_horizon", None)
         cumulative_probability: float = kwargs.pop("cumulative_probability", None)
         beliefs: List[TimedBelief] = kwargs.pop("beliefs", None)
@@ -606,7 +610,7 @@ class BeliefsDataFrame(pd.DataFrame):
                         source_utils.ensure_source_exists
                     )
                 if event_start is not None:
-                    self["event_start"] = tb_utils.enforce_tz(
+                    self["event_start"] = tb_utils.parse_datetime_like(
                         event_start, "event_start"
                     )
                 elif "event_start" not in self and "event_end" not in self:
@@ -615,10 +619,10 @@ class BeliefsDataFrame(pd.DataFrame):
                     )
                 else:
                     self["event_start"] = self["event_start"].apply(
-                        lambda x: tb_utils.enforce_tz(pd.to_datetime(x), "event_start")
+                        lambda x: tb_utils.parse_datetime_like(x, "event_start")
                     )
                 if belief_time is not None:
-                    self["belief_time"] = tb_utils.enforce_tz(
+                    self["belief_time"] = tb_utils.parse_datetime_like(
                         belief_time, "belief_time"
                     )
                 elif belief_horizon is not None:
@@ -629,7 +633,7 @@ class BeliefsDataFrame(pd.DataFrame):
                     )
                 elif "belief_time" in self:
                     self["belief_time"] = self["belief_time"].apply(
-                        lambda x: tb_utils.enforce_tz(pd.to_datetime(x), "belief_time")
+                        lambda x: tb_utils.parse_datetime_like(x, "belief_time")
                     )
                 elif not pd.api.types.is_timedelta64_dtype(
                     self["belief_horizon"]
@@ -665,7 +669,9 @@ class BeliefsDataFrame(pd.DataFrame):
                     ]
                 self.set_index(indices, inplace=True)
 
-        assign_sensor_and_event_resolution(self, sensor, event_resolution)
+        assign_sensor_and_event_resolution(
+            self, sensor, tb_utils.parse_timedelta_like(event_resolution)
+        )
 
     def append_from_time_series(
         self,
@@ -813,12 +819,14 @@ class BeliefsDataFrame(pd.DataFrame):
     @hybrid_method
     def belief_history(
         self,
-        event_start: datetime,
-        belief_time_window: Tuple[Optional[datetime], Optional[datetime]] = (
+        event_start: DatetimeLike,
+        belief_time_window: Tuple[Optional[DatetimeLike], Optional[DatetimeLike]] = (
             None,
             None,
         ),
-        belief_horizon_window: Tuple[Optional[timedelta], Optional[timedelta]] = (
+        belief_horizon_window: Tuple[
+            Optional[TimedeltaLike], Optional[TimedeltaLike]
+        ] = (
             None,
             None,
         ),
@@ -848,14 +856,20 @@ class BeliefsDataFrame(pd.DataFrame):
             return self
 
         df = self.xs(
-            tb_utils.enforce_tz(event_start, "event_start"),
+            tb_utils.parse_datetime_like(event_start, "event_start"),
             level="event_start",
             drop_level=False,
         ).sort_index()
         if belief_time_window[0] is not None:
-            df = df[df.index.get_level_values("belief_time") >= belief_time_window[0]]
+            df = df[
+                df.index.get_level_values("belief_time")
+                >= tb_utils.parse_datetime_like(belief_time_window[0], "belief_time")
+            ]
         if belief_time_window[1] is not None:
-            df = df[df.index.get_level_values("belief_time") <= belief_time_window[1]]
+            df = df[
+                df.index.get_level_values("belief_time")
+                <= tb_utils.parse_datetime_like(belief_time_window[1], "belief_time")
+            ]
         if belief_horizon_window != (None, None):
             if belief_time_window != (None, None):
                 raise ValueError(
@@ -865,12 +879,12 @@ class BeliefsDataFrame(pd.DataFrame):
             if belief_horizon_window[0] is not None:
                 df = df[
                     df.index.get_level_values("belief_horizon")
-                    >= belief_horizon_window[0]
+                    >= tb_utils.parse_timedelta_like(belief_horizon_window[0])
                 ]
             if belief_horizon_window[1] is not None:
                 df = df[
                     df.index.get_level_values("belief_horizon")
-                    <= belief_horizon_window[1]
+                    <= tb_utils.parse_timedelta_like(belief_horizon_window[1])
                 ]
             df = df.convert_index_from_belief_horizon_to_time()
         if not keep_event_start:
@@ -880,8 +894,8 @@ class BeliefsDataFrame(pd.DataFrame):
     @hybrid_method
     def fixed_viewpoint(
         self,
-        belief_time: datetime = None,
-        belief_time_window: Tuple[Optional[datetime], Optional[datetime]] = (
+        belief_time: DatetimeLike = None,
+        belief_time_window: Tuple[Optional[DatetimeLike], Optional[DatetimeLike]] = (
             None,
             None,
         ),
@@ -921,12 +935,12 @@ class BeliefsDataFrame(pd.DataFrame):
         if belief_time_window[0] is not None:
             df = df[
                 df.index.get_level_values("belief_time")
-                >= tb_utils.enforce_tz(belief_time_window[0], "belief_time")
+                >= tb_utils.parse_datetime_like(belief_time_window[0], "belief_time")
             ]
         if belief_time_window[1] is not None:
             df = df[
                 df.index.get_level_values("belief_time")
-                <= tb_utils.enforce_tz(belief_time_window[1], "belief_time")
+                <= tb_utils.parse_datetime_like(belief_time_window[1], "belief_time")
             ]
         df = belief_utils.select_most_recent_belief(df)
         if update_belief_times is True:
@@ -941,8 +955,10 @@ class BeliefsDataFrame(pd.DataFrame):
     @hybrid_method
     def rolling_viewpoint(
         self,
-        belief_horizon: timedelta = None,
-        belief_horizon_window: Tuple[Optional[timedelta], Optional[timedelta]] = (
+        belief_horizon: TimedeltaLike = None,
+        belief_horizon_window: Tuple[
+            Optional[TimedeltaLike], Optional[TimedeltaLike]
+        ] = (
             None,
             None,
         ),
@@ -983,18 +999,20 @@ class BeliefsDataFrame(pd.DataFrame):
             df = df.convert_index_from_belief_time_to_horizon()
         if belief_horizon_window[0] is not None:
             df = df[
-                df.index.get_level_values("belief_horizon") >= belief_horizon_window[0]
+                df.index.get_level_values("belief_horizon")
+                >= tb_utils.parse_timedelta_like(belief_horizon_window[0])
             ]
         if belief_horizon_window[1] is not None:
             df = df[
-                df.index.get_level_values("belief_horizon") <= belief_horizon_window[1]
+                df.index.get_level_values("belief_horizon")
+                <= tb_utils.parse_timedelta_like(belief_horizon_window[1])
             ]
         return belief_utils.select_most_recent_belief(df)
 
     @hybrid_method
     def resample_events(
         self,
-        event_resolution: timedelta,
+        event_resolution: TimedeltaLike,
         distribution: Optional[str] = None,
         keep_only_most_recent_belief: bool = False,
     ) -> "BeliefsDataFrame":
@@ -1006,6 +1024,7 @@ class BeliefsDataFrame(pd.DataFrame):
 
         if self.empty:
             return self
+        event_resolution = tb_utils.parse_timedelta_like(event_resolution)
         if event_resolution == self.event_resolution:
             return self
         df = self

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -52,7 +52,8 @@ class TimedBelief(object):
         self,
         sensor: Sensor,
         source: Union[BeliefSource, str, int],
-        value: float,
+        event_value: Optional[float] = None,
+        value: Optional[float] = None,
         cumulative_probability: Optional[float] = None,
         cp: Optional[float] = None,
         sigma: Optional[float] = None,
@@ -63,7 +64,15 @@ class TimedBelief(object):
     ):
         self.sensor = sensor
         self.source = source_utils.ensure_source_exists(source)
-        self.event_value = value
+        if event_value is None and value is None:
+            raise ValueError("Missing argument: event_value.")
+        elif event_value is not None:
+            self.event_value = event_value
+        else:
+            # todo: deprecate the 'value' argument in favor of 'event_value'
+            import warnings
+            warnings.warn("Argument 'value' will be replaced by 'event_value'. Replace 'value' with 'event_value' to suppress this warning.", FutureWarning)
+            self.event_value = value
 
         if [cumulative_probability, cp, sigma].count(None) not in (2, 3):
             raise ValueError(

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -73,7 +73,11 @@ class TimedBelief(object):
         else:
             # todo: deprecate the 'value' argument in favor of 'event_value'
             import warnings
-            warnings.warn("Argument 'value' will be replaced by 'event_value'. Replace 'value' with 'event_value' to suppress this warning.", FutureWarning)
+
+            warnings.warn(
+                "Argument 'value' will be replaced by 'event_value'. Replace 'value' with 'event_value' to suppress this warning.",
+                FutureWarning,
+            )
             self.event_value = value
 
         if [cumulative_probability, cp, sigma].count(None) not in (2, 3):

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -1529,6 +1529,3 @@ def downsample_beliefs_data_frame(
         ],
         axis=1,
     ).set_index([belief_timing_col, "source", "cumulative_probability"], append=True)
-
-
-Belief = TimedBelief

--- a/timely_beliefs/docs/init.md
+++ b/timely_beliefs/docs/init.md
@@ -16,18 +16,21 @@ Each belief requires a `Sensor` and a `BeliefSource`. For example:
     >>> sensor = tb.Sensor("EPEX SPOT day-ahead price", event_resolution=timedelta(hours=1), unit="EUR/MWh")
     >>> source = tb.BeliefSource("EPEX")
 
-When creating a `BeliefsDataFrame`, a sensor always needs to be passes.
+When creating a `BeliefsDataFrame`, a sensor always needs to be passed.
+A `BeliefsDataFrame` can only refer to a single sensor.
 A source can be passed once for the entire frame, or per belief.
 
 ## From a Pandas Series
 
-Create a BeliefsDataFrame from a conventional time series (Pandas Series with DatetimeIndex) together with keyword arguments.
+Create a BeliefsDataFrame from a conventional time series (a Pandas Series with a DatetimeIndex) together with keyword arguments.
 
 Required arguments:
 
-- either `belief_time` or `belief_horizon`
-- `source` (only a single source can be provided)
-- `sensor`
+- either:
+  - `belief_time` (one moment at which all beliefs were formed), or
+  - `belief_horizon` (each belief was formed the same duration before or after)
+- `source` (one source for all beliefs)
+- `sensor` (one sensor to which all beliefs refer)
 
 
     >>> import pandas as pd
@@ -51,7 +54,7 @@ Pass a Pandas DataFrame with columns ["event_start", "belief_time", "source", "c
     2000-01-03 09:00:00+00:00 0 days         EPEX   0.5                              63
     2000-01-03 10:00:00+00:00 0 days         EPEX   0.5                              60
 
-Alternatively, keyword arguments can be used to replace columns that contain unique values for each belief.
+Alternatively, a keyword argument can be used to replace a column that contains the same value for each belief.
 
     >>> df = pd.DataFrame([[63, datetime(2000, 1, 3, 9, tzinfo=pytz.utc)], [60, datetime(2000, 1, 3, 10, tzinfo=pytz.utc)]], columns=["event_value", "event_start"])
     >>> bdf = tb.BeliefsDataFrame(df, belief_horizon=timedelta(hours=0), source=source, sensor=sensor)
@@ -63,8 +66,17 @@ Alternatively, keyword arguments can be used to replace columns that contain uni
 
 ## From a CSV file
 
-The utility function `tb.read_csv` lets you load a BeliefsDataFrame from a csv file (e.g. example/temperature.csv).
+The utility function `tb.read_csv` lets you load a BeliefsDataFrame from a csv file.
 You still need to set the source and sensor for the BeliefsDataFrame; the csv file only contains their names.
+
+An example, adapted from `timely_beliefs/example/__init__.py`:
+
+    temperature_df = tb.read_csv(
+        "temperature.csv",
+        sensor=tb.Sensor("Thermometer A", unit="°C", event_resolution=timedelta(hours=1)),
+        source=tb.BeliefSource("Source X"),
+    )
+
 In case the csv file contains multiple source names, you can pass a list of sources.
 Each source name will then be replaced by the actual `Source` object from the list you provided.
 To write a BeliefsDataFrame to a csv file, just use the pandas way:
@@ -75,8 +87,6 @@ To write a BeliefsDataFrame to a csv file, just use the pandas way:
 ## From a list of TimedBeliefs
 
 Create a list of `TimedBelief` or `DBTimedBelief` objects and use it to initialize a BeliefsDataFrame.
-
-_This method is meant for applications with a database._
 
     >>> from datetime import datetime, timedelta
     >>> import pytz

--- a/timely_beliefs/docs/init.md
+++ b/timely_beliefs/docs/init.md
@@ -1,0 +1,91 @@
+# Creating a BeliefsDataFrame
+
+## Table of contents
+
+1. [Sensors and BeliefSources](#sensors-and-beliefsources)
+1. [From a Pandas Series](#from-a-pandas-series)
+1. [From a Pandas DataFrame](#from-a-pandas-dataframe)
+1. [From a CSV file](#from-a-csv-file)
+1. [From a list of TimedBeliefs](#from-a-list-of-timedbeliefs)
+
+## Sensors and BeliefSources
+
+Each belief requires a `Sensor` and a `BeliefSource`. For example:
+
+    >>> import timely_beliefs as tb
+    >>> sensor = tb.Sensor("EPEX SPOT day-ahead price", event_resolution=timedelta(hours=1), unit="EUR/MWh")
+    >>> source = tb.BeliefSource("EPEX")
+
+When creating a `BeliefsDataFrame`, a sensor always needs to be passes.
+A source can be passed once for the entire frame, or per belief.
+
+## From a Pandas Series
+
+Create a BeliefsDataFrame from a conventional time series (Pandas Series with DatetimeIndex) together with keyword arguments.
+
+Required arguments:
+
+- either `belief_time` or `belief_horizon`
+- `source` (only a single source can be provided)
+- `sensor`
+
+
+    >>> import pandas as pd
+    >>> s = pd.Series([63, 60], index=pd.date_range(datetime(2000, 1, 3, 9), periods=2, tz=pytz.utc))
+    >>> bdf = tb.BeliefsDataFrame(s, belief_horizon=timedelta(hours=0), source=source, sensor=sensor)
+    >>> print(bdf)
+                                                                            event_value
+    event_start               belief_horizon source cumulative_probability             
+    2000-01-03 09:00:00+00:00 0 days         EPEX   0.5                              63
+    2000-01-04 09:00:00+00:00 0 days         EPEX   0.5                              60
+
+## From a Pandas DataFrame
+
+Pass a Pandas DataFrame with columns ["event_start", "belief_time", "source", "cumulative_probability", "event_value"]. The "cumulative_probability" column is optional (a default of 0.5 will be used if the column is missing).
+
+    >>> df = pd.DataFrame([[63, datetime(2000, 1, 3, 9, tzinfo=pytz.utc), timedelta(hours=0), source], [60, datetime(2000, 1, 3, 10, tzinfo=pytz.utc), timedelta(hours=0), source]], columns=["event_value", "event_start", "belief_horizon", "source"])
+    >>> bdf = tb.BeliefsDataFrame(df, sensor=sensor)
+    >>> print(bdf)
+                                                                            event_value
+    event_start               belief_horizon source cumulative_probability             
+    2000-01-03 09:00:00+00:00 0 days         EPEX   0.5                              63
+    2000-01-03 10:00:00+00:00 0 days         EPEX   0.5                              60
+
+Alternatively, keyword arguments can be used to replace columns that contain unique values for each belief.
+
+    >>> df = pd.DataFrame([[63, datetime(2000, 1, 3, 9, tzinfo=pytz.utc)], [60, datetime(2000, 1, 3, 10, tzinfo=pytz.utc)]], columns=["event_value", "event_start"])
+    >>> bdf = tb.BeliefsDataFrame(df, belief_horizon=timedelta(hours=0), source=source, sensor=sensor)
+    >>> print(bdf)
+                                                                            event_value
+    event_start               belief_horizon source cumulative_probability             
+    2000-01-03 09:00:00+00:00 0 days         EPEX   0.5                              63
+    2000-01-03 10:00:00+00:00 0 days         EPEX   0.5                              60
+
+## From a CSV file
+
+The utility function `tb.read_csv` lets you load a BeliefsDataFrame from a csv file (e.g. example/temperature.csv).
+You still need to set the source and sensor for the BeliefsDataFrame; the csv file only contains their names.
+In case the csv file contains multiple source names, you can pass a list of sources.
+Each source name will then be replaced by the actual `Source` object from the list you provided.
+To write a BeliefsDataFrame to a csv file, just use the pandas way:
+
+    >>> bdf.to_csv("data.csv")
+    >>> tb.read_csv("data.csv", source=source, sensor=sensor)
+
+## From a list of TimedBeliefs
+
+Create a list of `TimedBelief` or `DBTimedBelief` objects and use it to initialize a BeliefsDataFrame.
+
+_This method is meant for applications with a database._
+
+    >>> from datetime import datetime, timedelta
+    >>> import pytz
+    >>> belief_1 = tb.TimedBelief(event_value=63, event_start=datetime(2000, 1, 3, 9, tzinfo=pytz.utc), belief_horizon=timedelta(hours=0), sensor=sensor, source=source)
+    >>> belief_2 = tb.TimedBelief(event_value=60, event_start=datetime(2000, 1, 3, 10, tzinfo=pytz.utc), belief_horizon=timedelta(hours=0), sensor=sensor, source=source)
+    >>> beliefs = [belief_1, belief_2]
+    >>> bdf = tb.BeliefsDataFrame(beliefs)
+    >>> print(bdf)
+                                                                                       event_value
+    event_start               belief_time               source cumulative_probability             
+    2000-01-03 09:00:00+00:00 2000-01-03 10:00:00+00:00 EPEX   0.5                              63
+    2000-01-03 10:00:00+00:00 2000-01-03 11:00:00+00:00 EPEX   0.5                              60

--- a/timely_beliefs/examples/beliefs_data_frames.py
+++ b/timely_beliefs/examples/beliefs_data_frames.py
@@ -29,7 +29,7 @@ def sixteen_probabilistic_beliefs() -> BeliefsDataFrame:
         TimedBelief(
             source=sources[s],
             sensor=example_sensor,
-            value=int(
+            event_value=int(
                 1
                 * (e + 1)
                 * (

--- a/timely_beliefs/tests/conftest.py
+++ b/timely_beliefs/tests/conftest.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+import sys
 
 import pytest
 
@@ -8,6 +9,11 @@ from timely_beliefs.sensors.func_store.knowledge_horizons import (
     determine_ex_ante_knowledge_horizon_for_x_days_ago_at_y_oclock,
 )
 from timely_beliefs.tests import engine, session
+
+
+if sys.version_info[0] == 3 and sys.version_info[1] == 6:
+    # Ignore these tests for python==3.6
+    collect_ignore = ["test_ignore_36.py"]
 
 
 @pytest.fixture(scope="function")

--- a/timely_beliefs/tests/test_belief_init.py
+++ b/timely_beliefs/tests/test_belief_init.py
@@ -1,9 +1,10 @@
 from datetime import datetime, timedelta
 
+import pandas as pd
 import pytest
 from pytz import utc
 
-from timely_beliefs import BeliefSource, Sensor, TimedBelief
+from timely_beliefs import BeliefSource, Sensor, TimedBelief, utils
 
 
 @pytest.fixture(scope="function")
@@ -87,3 +88,30 @@ def test_day_ahead_belief_about_ex_post_time_slot_event(
     ) - day_ahead_belief_about_ex_post_time_slot_event.sensor.knowledge_horizon(
         day_ahead_belief_about_ex_post_time_slot_event.event_start
     )
+
+
+@pytest.mark.parametrize(
+    "dt, ErrorType, match",
+    [
+        ("someday", ValueError, "not parse"),
+        ("2003-01-05", TypeError, "timezone-naive"),
+        (pd.Timestamp("2003-01-05").to_datetime64(), TypeError, "timezone-naive"),
+    ],
+)
+def test_datetime_parsing(dt, ErrorType, match):
+    with pytest.raises(ErrorType, match=match):
+        utils.parse_datetime_like(dt)
+
+
+@pytest.mark.parametrize(
+    "td, ErrorType, match",
+    [
+        ("a while", ValueError, "not parse"),
+        ("1M", ValueError, "not parse"),
+        ("1Y", ValueError, "not parse"),
+        ("1y", ValueError, "not parse"),
+    ],
+)
+def test_timedelta_parsing(td, ErrorType, match):
+    with pytest.raises(ErrorType, match=match):
+        utils.parse_timedelta_like(td)

--- a/timely_beliefs/tests/test_belief_init.py
+++ b/timely_beliefs/tests/test_belief_init.py
@@ -107,9 +107,6 @@ def test_datetime_parsing(dt, ErrorType, match):
     "td, ErrorType, match",
     [
         ("a while", ValueError, "not parse"),
-        ("1M", ValueError, "not parse"),
-        ("1Y", ValueError, "not parse"),
-        ("1y", ValueError, "not parse"),
     ],
 )
 def test_timedelta_parsing(td, ErrorType, match):

--- a/timely_beliefs/tests/test_ignore_36.py
+++ b/timely_beliefs/tests/test_ignore_36.py
@@ -1,0 +1,16 @@
+import pytest
+
+from timely_beliefs import utils
+
+
+@pytest.mark.parametrize(
+    "td, ErrorType, match",
+    [
+        ("1M", ValueError, "not parse"),
+        ("1Y", ValueError, "not parse"),
+        ("1y", ValueError, "not parse"),
+    ],
+)
+def test_ambiguous_timedelta_parsing(td, ErrorType, match):
+    with pytest.raises(ErrorType, match=match):
+        utils.parse_timedelta_like(td)

--- a/timely_beliefs/utils.py
+++ b/timely_beliefs/utils.py
@@ -27,7 +27,7 @@ def parse_timedelta_like(
                 td = pd.Timedelta(td)
             if isinstance(td, pd.Timedelta):
                 td = td.to_pytimedelta()
-    except (ValueError, TypeError, DeprecationWarning, FutureWarning) as e:
+    except (ValueError, FutureWarning) as e:
         raise ValueError(
             f"Could not parse {variable_name if variable_name else 'timedelta'} {td}, because {e}"
         )

--- a/timely_beliefs/utils.py
+++ b/timely_beliefs/utils.py
@@ -27,7 +27,7 @@ def parse_timedelta_like(
                 td = pd.Timedelta(td)
             if isinstance(td, pd.Timedelta):
                 td = td.to_pytimedelta()
-    except (ValueError, FutureWarning) as e:
+    except (ValueError, DeprecationWarning, FutureWarning) as e:
         raise ValueError(
             f"Could not parse {variable_name if variable_name else 'timedelta'} {td}, because {e}"
         )

--- a/timely_beliefs/utils.py
+++ b/timely_beliefs/utils.py
@@ -27,7 +27,7 @@ def parse_timedelta_like(
                 td = pd.Timedelta(td)
             if isinstance(td, pd.Timedelta):
                 td = td.to_pytimedelta()
-    except (ValueError, DeprecationWarning, FutureWarning) as e:
+    except (ValueError, TypeError, DeprecationWarning, FutureWarning) as e:
         raise ValueError(
             f"Could not parse {variable_name if variable_name else 'timedelta'} {td}, because {e}"
         )

--- a/timely_beliefs/utils.py
+++ b/timely_beliefs/utils.py
@@ -1,10 +1,36 @@
-from datetime import datetime
-from typing import Optional, Sequence
+from datetime import datetime, timedelta
+from typing import Optional, Sequence, Union
 
 import pandas as pd
 
 
+def parse_timedelta_like(
+    td: Union[timedelta, str, pd.Timedelta],
+) -> timedelta:
+    """Parse timedelta like objects as a datetime.timedelta object."""
+    if isinstance(td, str):
+        td = pd.Timedelta(td)
+    if isinstance(td, pd.Timedelta):
+        td = td.to_pytimedelta()
+    return td
+
+
+def parse_datetime_like(
+    dt: Union[datetime, str, pd.Timestamp], name: Optional[str]
+) -> datetime:
+    """Parse datetime like objects as a datetime.datetime object."""
+    if isinstance(dt, str):
+        dt = pd.Timestamp(dt)
+    if isinstance(dt, pd.Timestamp):
+        dt = dt.to_pydatetime()
+    return enforce_tz(dt, name)
+
+
 def enforce_tz(dt: datetime, name: Optional[str]) -> datetime:
+    if not hasattr(dt, "tzinfo"):
+        raise TypeError(
+            f"The timely-beliefs package works with timezone-aware datetimes. Please use a localized {name if name else 'datetime'} {dt}."
+        )
     if dt.tzinfo is None:
         raise TypeError(
             f"The timely-beliefs package does not work with timezone-naive datetimes. Please localize your {name if name else 'datetime'} {dt}."


### PR DESCRIPTION
I added a long overdue documentation section on different ways to initialize a BeliefsDataFrame, which was mostly still hidden in 
its class docstring, and included the shortest possible way near the top of the main Readme, too. I also took the opportunity to 1) build in some flexibility to specify durations and timestamps in different formats, 2) rename a variable, and 3) add a shorthand for a TimedBelief, just Belief seems nice.