### PR TITLE
Issue 46 use constants to shorten the knowledge horizon functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "uncertainty",
         "lineage",
     ],
-    version="1.1.0",
+    version="1.2.0",
     install_requires=[
         "pytz",
         "pandas>=1.1.5",

--- a/timely_beliefs/sensors/classes.py
+++ b/timely_beliefs/sensors/classes.py
@@ -5,10 +5,7 @@ from sqlalchemy import JSON, Column, Integer, Interval, String
 from sqlalchemy.ext.hybrid import hybrid_method
 
 from timely_beliefs.db_base import Base
-from timely_beliefs.sensors.func_store.knowledge_horizons import (
-    determine_ex_ante_knowledge_horizon,
-    determine_ex_post_knowledge_horizon,
-)
+from timely_beliefs.sensors.func_store import knowledge_horizons
 from timely_beliefs.sensors.utils import (
     eval_verified_knowledge_horizon_fnc,
     jsonify_time_dict,
@@ -50,16 +47,16 @@ class Sensor(object):
         self.event_resolution = event_resolution
         if knowledge_horizon is None:
             # Set an appropriate knowledge horizon for physical sensors, representing ex-post knowledge time.
-            self.knowledge_horizon_fnc = determine_ex_post_knowledge_horizon.__name__
+            self.knowledge_horizon_fnc = "EX_POST"
             knowledge_horizon_par = {
-                determine_ex_post_knowledge_horizon.__code__.co_varnames[1]: timedelta(
-                    hours=0
-                )
+                knowledge_horizons.shorthands["EX_POST"].__code__.co_varnames[
+                    1
+                ]: timedelta(hours=0)
             }
         elif isinstance(knowledge_horizon, timedelta):
-            self.knowledge_horizon_fnc = determine_ex_ante_knowledge_horizon.__name__
+            self.knowledge_horizon_fnc = "EX_ANTE"
             knowledge_horizon_par = {
-                determine_ex_ante_knowledge_horizon.__code__.co_varnames[
+                knowledge_horizons.shorthands["EX_ANTE"].__code__.co_varnames[
                     0
                 ]: knowledge_horizon
             }
@@ -110,17 +107,15 @@ class SensorDBMixin(Sensor):
     unit = Column(String(80), nullable=False, default="")
     timezone = Column(String(80), nullable=False, default="UTC")
     event_resolution = Column(Interval(), nullable=False, default=timedelta(hours=0))
-    knowledge_horizon_fnc = Column(
-        String(80), nullable=False, default=determine_ex_post_knowledge_horizon.__name__
-    )
+    knowledge_horizon_fnc = Column(String(80), nullable=False, default="EX_POST")
     knowledge_horizon_par = Column(
         JSON(),
         nullable=False,
         default=jsonify_time_dict(
             {
-                determine_ex_post_knowledge_horizon.__code__.co_varnames[1]: timedelta(
-                    hours=0
-                )
+                knowledge_horizons.shorthands["EX_POST"].__code__.co_varnames[
+                    1
+                ]: timedelta(hours=0)
             }
         ),
     )

--- a/timely_beliefs/sensors/classes.py
+++ b/timely_beliefs/sensors/classes.py
@@ -47,18 +47,14 @@ class Sensor(object):
         self.event_resolution = event_resolution
         if knowledge_horizon is None:
             # Set an appropriate knowledge horizon for physical sensors, representing ex-post knowledge time.
-            self.knowledge_horizon_fnc = "EX_POST"
+            self.knowledge_horizon_fnc = knowledge_horizons.ex_post.__name__
             knowledge_horizon_par = {
-                knowledge_horizons.shorthands["EX_POST"].__code__.co_varnames[
-                    1
-                ]: timedelta(hours=0)
+                knowledge_horizons.ex_post.__code__.co_varnames[1]: timedelta(hours=0)
             }
         elif isinstance(knowledge_horizon, timedelta):
-            self.knowledge_horizon_fnc = "EX_ANTE"
+            self.knowledge_horizon_fnc = knowledge_horizons.ex_ante.__name__
             knowledge_horizon_par = {
-                knowledge_horizons.shorthands["EX_ANTE"].__code__.co_varnames[
-                    0
-                ]: knowledge_horizon
+                knowledge_horizons.ex_ante.__code__.co_varnames[0]: knowledge_horizon
             }
         elif isinstance(knowledge_horizon, Tuple):
             self.knowledge_horizon_fnc = knowledge_horizon[0].__name__
@@ -107,16 +103,14 @@ class SensorDBMixin(Sensor):
     unit = Column(String(80), nullable=False, default="")
     timezone = Column(String(80), nullable=False, default="UTC")
     event_resolution = Column(Interval(), nullable=False, default=timedelta(hours=0))
-    knowledge_horizon_fnc = Column(String(80), nullable=False, default="EX_POST")
+    knowledge_horizon_fnc = Column(
+        String(80), nullable=False, default=knowledge_horizons.ex_post.__name__
+    )
     knowledge_horizon_par = Column(
         JSON(),
         nullable=False,
         default=jsonify_time_dict(
-            {
-                knowledge_horizons.shorthands["EX_POST"].__code__.co_varnames[
-                    1
-                ]: timedelta(hours=0)
-            }
+            {knowledge_horizons.ex_post.__code__.co_varnames[1]: timedelta(hours=0)}
         ),
     )
 

--- a/timely_beliefs/sensors/classes.py
+++ b/timely_beliefs/sensors/classes.py
@@ -110,8 +110,20 @@ class SensorDBMixin(Sensor):
     unit = Column(String(80), nullable=False, default="")
     timezone = Column(String(80), nullable=False, default="UTC")
     event_resolution = Column(Interval(), nullable=False, default=timedelta(hours=0))
-    knowledge_horizon_fnc = Column(String(80), nullable=False)
-    knowledge_horizon_par = Column(JSON(), default={}, nullable=False)
+    knowledge_horizon_fnc = Column(
+        String(80), nullable=False, default=determine_ex_post_knowledge_horizon.__name__
+    )
+    knowledge_horizon_par = Column(
+        JSON(),
+        nullable=False,
+        default=jsonify_time_dict(
+            {
+                determine_ex_post_knowledge_horizon.__code__.co_varnames[1]: timedelta(
+                    hours=0
+                )
+            }
+        ),
+    )
 
     def __init__(
         self,

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -7,7 +7,7 @@ from typing import Optional, Tuple, Union
 from timely_beliefs.sensors.utils import datetime_x_days_ago_at_y_oclock
 
 
-def determine_knowledge_horizon_for_fixed_knowledge_time(
+def at_date(
     event_start: Optional[datetime],
     knowledge_time: datetime,
     get_bounds: bool = False,
@@ -28,7 +28,7 @@ def determine_knowledge_horizon_for_fixed_knowledge_time(
     return event_start - knowledge_time
 
 
-def determine_ex_post_knowledge_horizon(
+def ex_post(
     event_resolution: timedelta,
     ex_post_horizon: timedelta,
     get_bounds: bool = False,
@@ -51,7 +51,7 @@ def determine_ex_post_knowledge_horizon(
     return -event_resolution - ex_post_horizon
 
 
-def determine_ex_ante_knowledge_horizon(
+def ex_ante(
     ex_ante_horizon: timedelta,
     get_bounds: bool = False,
 ) -> Union[timedelta, Tuple[timedelta, timedelta]]:
@@ -67,7 +67,7 @@ def determine_ex_ante_knowledge_horizon(
     return ex_ante_horizon
 
 
-def determine_ex_ante_knowledge_horizon_for_x_days_ago_at_y_oclock(
+def x_days_ago_at_y_oclock(
     event_start: Optional[datetime],
     x: int,
     y: Union[int, float],
@@ -92,10 +92,60 @@ def determine_ex_ante_knowledge_horizon_for_x_days_ago_at_y_oclock(
     return event_start - datetime_x_days_ago_at_y_oclock(event_start, x, y, z)
 
 
-# Define some shorthands
-shorthands = {
-    "AT_DATE": determine_knowledge_horizon_for_fixed_knowledge_time,
-    "EX_POST": determine_ex_post_knowledge_horizon,
-    "EX_ANTE": determine_ex_ante_knowledge_horizon,
-    "EX_ANTE_X_DAYS_AT_Y_OCLOCK": determine_ex_ante_knowledge_horizon_for_x_days_ago_at_y_oclock,
-}
+# todo: deprecate this function
+def determine_knowledge_horizon_for_fixed_knowledge_time(
+    event_start: Optional[datetime],
+    *args,
+    **kwargs,
+):
+    import warnings
+
+    warnings.warn(
+        "Function name will be replaced by shorthand. Replace with 'at_date' to suppress this warning.",
+        FutureWarning,
+    )
+    return at_date(event_start, *args, **kwargs)
+
+
+# todo: deprecate this function
+def determine_ex_post_knowledge_horizon(
+    event_resolution: timedelta,
+    *args,
+    **kwargs,
+):
+    import warnings
+
+    warnings.warn(
+        "Function name will be replaced by shorthand. Replace with 'ex_post' to suppress this warning.",
+        FutureWarning,
+    )
+    return ex_post(event_resolution, *args, **kwargs)
+
+
+# todo: deprecate this function
+def determine_ex_ante_knowledge_horizon(
+    *args,
+    **kwargs,
+):
+    import warnings
+
+    warnings.warn(
+        "Function name will be replaced by shorthand. Replace with 'ex_ante' to suppress this warning.",
+        FutureWarning,
+    )
+    return ex_ante(*args, **kwargs)
+
+
+# todo: deprecate this function
+def determine_ex_ante_knowledge_horizon_for_x_days_ago_at_y_oclock(
+    event_start: Optional[datetime],
+    *args,
+    **kwargs,
+):
+    import warnings
+
+    warnings.warn(
+        "Function name will be replaced by shorthand. Replace with 'x_days_ago_at_y_oclock' to suppress this warning.",
+        FutureWarning,
+    )
+    return x_days_ago_at_y_oclock(event_start, *args, **kwargs)

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -90,3 +90,12 @@ def determine_ex_ante_knowledge_horizon_for_x_days_ago_at_y_oclock(
             timedelta(days=x + 1, hours=-y + 2),
         )  # The 2's account for possible hour differences for double daylight saving time w.r.t. standard time
     return event_start - datetime_x_days_ago_at_y_oclock(event_start, x, y, z)
+
+
+# Define some shorthands
+shorthands = {
+    "AT_DATE": determine_knowledge_horizon_for_fixed_knowledge_time,
+    "EX_POST": determine_ex_post_knowledge_horizon,
+    "EX_ANTE": determine_ex_ante_knowledge_horizon,
+    "EX_ANTE_X_DAYS_AT_Y_OCLOCK": determine_ex_ante_knowledge_horizon_for_x_days_ago_at_y_oclock,
+}

--- a/timely_beliefs/sensors/utils.py
+++ b/timely_beliefs/sensors/utils.py
@@ -69,10 +69,11 @@ def unjsonify_time_dict(d: dict) -> dict:
 
 
 def func_store_list() -> dict:
-    """Returns a dictionary with function names and Callable objects supported in our function store."""
+    """Returns a dictionary with function names (incl. shorthands) and Callable objects supported in our function store."""
     functions_dict = {
         o[0]: o[1] for o in getmembers(knowledge_horizons) if isfunction(o[1])
     }
+    functions_dict = {**functions_dict, **knowledge_horizons.shorthands}
     return functions_dict
 
 

--- a/timely_beliefs/sensors/utils.py
+++ b/timely_beliefs/sensors/utils.py
@@ -68,7 +68,7 @@ def unjsonify_time_dict(d: dict) -> dict:
     return d2
 
 
-def func_store_list() -> dict:
+def get_func_store() -> dict:
     """Returns a dictionary with function names (incl. shorthands) and Callable objects supported in our function store."""
     functions_dict = {
         o[0]: o[1] for o in getmembers(knowledge_horizons) if isfunction(o[1])
@@ -88,7 +88,7 @@ def eval_verified_knowledge_horizon_fnc(
     Only function names that represent Callable objects in our function store can be evaluated.
     If get_bounds is True, a tuple is returned with bounds on the possible return value.
     """
-    for verified_fnc_name, verified_fnc in func_store_list().items():
+    for verified_fnc_name, verified_fnc in get_func_store().items():
         if verified_fnc_name == requested_fnc_name:
             if {"event_start", "event_resolution"} < set(
                 getfullargspec(verified_fnc).args

--- a/timely_beliefs/sensors/utils.py
+++ b/timely_beliefs/sensors/utils.py
@@ -69,12 +69,9 @@ def unjsonify_time_dict(d: dict) -> dict:
 
 
 def get_func_store() -> dict:
-    """Returns a dictionary with function names (incl. shorthands) and Callable objects supported in our function store."""
-    functions_dict = {
-        o[0]: o[1] for o in getmembers(knowledge_horizons) if isfunction(o[1])
-    }
-    functions_dict = {**functions_dict, **knowledge_horizons.shorthands}
-    return functions_dict
+    """Returns a dictionary with Callable objects supported in our function store,
+    indexed by their function names."""
+    return {o[0]: o[1] for o in getmembers(knowledge_horizons) if isfunction(o[1])}
 
 
 def eval_verified_knowledge_horizon_fnc(

--- a/timely_beliefs/tests/test_df_resampling.py
+++ b/timely_beliefs/tests/test_df_resampling.py
@@ -60,7 +60,7 @@ def df_4323(
     probabilistic values.
     Note that the event resolution of the sensor is 15 minutes.
     """
-    start = pytz.timezone("utc").localize(datetime(2000, 1, 3, 9,))
+    start = pytz.timezone("utc").localize(datetime(2000, 1, 3, 9))
     return df_wxyz(4, 3, 2, 3, start)
 
 

--- a/timely_beliefs/visualization/graphs.py
+++ b/timely_beliefs/visualization/graphs.py
@@ -300,7 +300,7 @@ def source_vs_hour_chart(
     )
 
 
-def deterministic_chart(probability_scale_range: Tuple[float, float],):
+def deterministic_chart(probability_scale_range: Tuple[float, float]):
     return (
         alt.Chart()
         .mark_circle(color="red")


### PR DESCRIPTION
This turned out to be harder than it looked. Defining shorthands while also keeping the longer function names, **and** allowing the shorthand names to be imported (which I referred to as _dynamically linked_), is to the best of my knowledge not possible without turning the knowledge_horizon functions into classes. For example, the formulation:
```
EX_POST = determine_ex_post_knowledge_horizon
```
still had the `__name__` property set to `"determine_ex_post_knowledge_horizon"`, so the longer name would still end up in the database.

I ended up with a trade-off, in which the shorthands are defined in a dictionary which can be imported and used to check of the shorthand is still valid.