### PR TITLE
Support timed belief db mixin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "uncertainty",
         "lineage",
     ],
-    version="1.2.1",
+    version="1.3.0",
     install_requires=[
         "pytz",
         "pandas>=1.1.5",

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -269,7 +269,7 @@ class TimedBeliefDBMixin(TimedBelief):
         event_not_before: Optional[datetime] = None,
         belief_before: Optional[datetime] = None,
         belief_not_before: Optional[datetime] = None,
-        source: Optional[Union[int, List[int], str, List[str]]] = None,
+        source: Optional[Union[BeliefSource, List[BeliefSource]]] = None,
     ) -> "BeliefsDataFrame":
         """Search a database session for beliefs about sensor events.
         :param session: the database session to use
@@ -278,7 +278,7 @@ class TimedBeliefDBMixin(TimedBelief):
         :param event_not_before: only return beliefs about events that start after this datetime (inclusive)
         :param belief_before: only return beliefs formed before this datetime (inclusive)
         :param belief_not_before: only return beliefs formed after this datetime (inclusive)
-        :param source: only return beliefs formed by the given source or list of sources (pass their id or name)
+        :param source: only return beliefs formed by the given source or list of sources
         :returns: a multi-index DataFrame with all relevant beliefs
 
         TODO: rename params for clarity: event_finished_before, event_starts_not_before (or similar), same for beliefs

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -230,18 +230,18 @@ class TimedBeliefDBMixin(TimedBelief):
         )
 
     @classmethod
-    def add_all(
+    def add_to_session(
         cls,
         session: Session,
         beliefs_data_frame: "BeliefsDataFrame",
         commit_transaction: bool = False,
     ):
-        """Add a BeliefsDataFrame as timed beliefs to the database session.
+        """Add a BeliefsDataFrame as timed beliefs to a database session.
 
         :param session: the database session to use
         :param beliefs_data_frame: the BeliefsDataFrame to be persisted
         :param commit_transaction: if True, the session is committed
-                                   if False, you can add still other data to the session
+                                   if False, you can still add other data to the session
                                    and commit it all within an atomic transaction
         """
         # Belief timing is stored as the belief horizon rather than as the belief time

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -75,7 +75,7 @@ class TimedBelief(object):
         elif event_value is not None:
             self.event_value = event_value
         else:
-            # todo: deprecate the 'value' argument in favor of 'event_value'
+            # todo: deprecate the 'value' argument in favor of 'event_value' (announced v1.1.0)
             import warnings
 
             warnings.warn(
@@ -259,7 +259,7 @@ class TimedBeliefDBMixin(TimedBelief):
     @tb_utils.append_doc_of("TimedBeliefDBMixin.query_all")
     def query(cls, *args, **kwargs):
         """Function will be deprecated. Please switch to using query_all."""
-        # todo: deprecate this function, which can clash with SQLAlchemy's Model.query()
+        # todo: deprecate this function (announced v1.3.0), which can clash with SQLAlchemy's Model.query()
         import warnings
 
         warnings.warn(

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -180,7 +180,7 @@ class TimedBeliefDBMixin(TimedBelief):
             )
         return None
 
-    event_start = Column(DateTime(timezone=True), primary_key=True)
+    event_start = Column(DateTime(timezone=True), primary_key=True, index=True)
     belief_horizon = Column(Interval(), nullable=False, primary_key=True)
     cumulative_probability = Column(Float, nullable=False, primary_key=True)
     event_value = Column(Float, nullable=False)
@@ -188,7 +188,10 @@ class TimedBeliefDBMixin(TimedBelief):
     @declared_attr
     def sensor_id(cls):
         return Column(
-            Integer(), ForeignKey("sensor.id", ondelete="CASCADE"), primary_key=True
+            Integer(),
+            ForeignKey("sensor.id", ondelete="CASCADE"),
+            primary_key=True,
+            index=True,
         )
 
     @declared_attr

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -240,9 +240,11 @@ class TimedBeliefDBMixin(TimedBelief):
 
         :param session: the database session to use
         :param beliefs_data_frame: the BeliefsDataFrame to be persisted
-        :param commit_transaction: if False, you can add still other data to the session
+        :param commit_transaction: if True, the session is committed
+                                   if False, you can add still other data to the session
                                    and commit it all within an atomic transaction
         """
+        # Belief timing is stored as the belief horizon rather than as the belief time
         belief_records = (
             beliefs_data_frame.convert_index_from_belief_time_to_horizon()
             .reset_index()

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -54,7 +54,7 @@ class TimedBelief(object):
     source: BeliefSource
     cumulative_probability: float
 
-    def __init__(
+    def __init__(  # noqa: C901 todo: the noqa can probably be removed when we deprecate the value argument
         self,
         sensor: Sensor,
         source: Union[BeliefSource, str, int],
@@ -250,28 +250,26 @@ class TimedBeliefDBMixin(TimedBelief):
             .reset_index()
             .to_dict("records")
         )
-        beliefs = [
-            cls(**dict(**d, sensor=beliefs_data_frame.sensor)) for d in belief_records
-        ]
+        beliefs = [cls(sensor=beliefs_data_frame.sensor, **d) for d in belief_records]
         session.add_all(beliefs)
         if commit_transaction:
             session.commit()
 
     @classmethod
-    @tb_utils.append_doc_of("TimedBeliefDBMixin.query_all")
+    @tb_utils.append_doc_of("TimedBeliefDBMixin.search_session")
     def query(cls, *args, **kwargs):
-        """Function will be deprecated. Please switch to using query_all."""
+        """Function will be deprecated. Please switch to using search_session."""
         # todo: deprecate this function (announced v1.3.0), which can clash with SQLAlchemy's Model.query()
         import warnings
 
         warnings.warn(
-            "Function 'query' will be replaced by 'query_all'.",
+            "Function 'query' will be replaced by 'search_session'.",
             FutureWarning,
         )
-        return cls.query_all(*args, **kwargs)
+        return cls.search_session(*args, **kwargs)
 
     @classmethod
-    def query_all(
+    def search_session(
         cls,
         session: Session,
         sensor: DBSensor,
@@ -283,7 +281,7 @@ class TimedBeliefDBMixin(TimedBelief):
         sensor_cls: Type[SensorDBMixin] = DBSensor,
         source_cls: Type[BeliefSourceDBMixin] = DBBeliefSource,
     ) -> "BeliefsDataFrame":
-        """Query beliefs about sensor events.
+        """Search a database session for beliefs about sensor events.
         :param session: the database session to use
         :param sensor: sensor to which the beliefs pertain
         :param event_before: only return beliefs about events that end before this datetime (inclusive)
@@ -367,7 +365,7 @@ class TimedBeliefDBMixin(TimedBelief):
                     if not isinstance(s, int) and not isinstance(s, str)
                 ]
                 raise ValueError(
-                    "Query by source failed: query only possible by integer id or string name. Failed sources: %s"
+                    "Search by source failed: search only possible by integer id or string name. Failed sources: %s"
                     % unidentifiable_list
                 )
             else:
@@ -541,9 +539,9 @@ class BeliefsDataFrame(pd.DataFrame):
                 object.__setattr__(self, name, getattr(other, name, None))
         return self
 
-    def __init__(  # noqa: C901
+    def __init__(  # noqa: C901 todo: refactor, e.g. by detecting initialization method
         self, *args, **kwargs
-    ):  # noqa: C901 todo: refactor, e.g. by detecting initialization method
+    ):
         """Initialise a multi-index DataFrame with beliefs about a unique sensor."""
 
         # Initialized with a BeliefsSeries or BeliefsDataFrame

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -225,7 +225,20 @@ class TimedBeliefDBMixin(TimedBelief):
         )
 
     @classmethod
-    def query(
+    @tb_utils.append_doc_of("TimedBeliefDBMixin.query_all")
+    def query(cls, *args, **kwargs):
+        """Function will be deprecated. Please switch to using query_all."""
+        # todo: deprecate this function, which can clash with SQLAlchemy's Model.query()
+        import warnings
+
+        warnings.warn(
+            "Function 'query' will be replaced by 'query_all'.",
+            FutureWarning,
+        )
+        return cls.query_all(*args, **kwargs)
+
+    @classmethod
+    def query_all(
         cls,
         session: Session,
         sensor: DBSensor,

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -66,19 +66,10 @@ class TimedBelief(object):
     ):
         self.sensor = sensor
         self.source = source_utils.ensure_source_exists(source)
-        if event_value is None and value is None:
-            raise ValueError("Missing argument: event_value.")
-        elif event_value is not None:
-            self.event_value = event_value
-        else:
-            # todo: deprecate the 'value' argument in favor of 'event_value' (announced v1.1.0)
-            import warnings
-
-            warnings.warn(
-                "Argument 'value' will be replaced by 'event_value'. Replace 'value' with 'event_value' to suppress this warning.",
-                FutureWarning,
-            )
-            self.event_value = value
+        # todo: deprecate the 'value' argument in favor of 'event_value' (announced v1.1.0)
+        self.event_value = tb_utils.replace_deprecated_argument(
+            "value", value, "event_value", event_value
+        )
 
         if [cumulative_probability, cp, sigma].count(None) not in (2, 3):
             raise ValueError(
@@ -200,7 +191,8 @@ class TimedBeliefDBMixin(TimedBelief):
         self,
         sensor: DBSensor,
         source: DBBeliefSource,
-        value: float,
+        event_value: Optional[float] = None,
+        value: Optional[float] = None,
         cumulative_probability: Optional[float] = None,
         cp: Optional[float] = None,
         sigma: Optional[float] = None,
@@ -209,13 +201,17 @@ class TimedBeliefDBMixin(TimedBelief):
         belief_horizon: Optional[TimedeltaLike] = None,
         belief_time: Optional[DatetimeLike] = None,
     ):
+        # todo: deprecate the 'value' argument in favor of 'event_value' (announced v1.3.0)
+        event_value = tb_utils.replace_deprecated_argument(
+            "value", value, "event_value", event_value
+        )
         self.sensor_id = sensor.id
         self.source_id = source.id
         TimedBelief.__init__(
             self,
             sensor=sensor,
             source=source,
-            value=value,
+            event_value=event_value,
             cumulative_probability=cumulative_probability,
             cp=cp,
             sigma=sigma,
@@ -389,7 +385,8 @@ class DBTimedBelief(Base, TimedBeliefDBMixin):
         self,
         sensor: DBSensor,
         source: DBBeliefSource,
-        value: float,
+        event_value: Optional[float] = None,
+        value: Optional[float] = None,
         cumulative_probability: Optional[float] = None,
         cp: Optional[float] = None,
         sigma: Optional[float] = None,
@@ -398,18 +395,22 @@ class DBTimedBelief(Base, TimedBeliefDBMixin):
         belief_horizon: Optional[TimedeltaLike] = None,
         belief_time: Optional[DatetimeLike] = None,
     ):
+        # todo: deprecate the 'value' argument in favor of 'event_value' (announced v1.3.0)
+        event_value = tb_utils.replace_deprecated_argument(
+            "value", value, "event_value", event_value
+        )
         TimedBeliefDBMixin.__init__(
             self,
-            sensor,
-            source,
-            value,
-            cumulative_probability,
-            cp,
-            sigma,
-            event_start,
-            event_time,
-            belief_horizon,
-            belief_time,
+            sensor=sensor,
+            source=source,
+            event_value=event_value,
+            cumulative_probability=cumulative_probability,
+            cp=cp,
+            sigma=sigma,
+            event_start=event_start,
+            event_time=event_time,
+            belief_horizon=belief_horizon,
+            belief_time=belief_time,
         )
         Base.__init__(self)
 

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -182,7 +182,9 @@ class TimedBeliefDBMixin(TimedBelief):
 
     event_start = Column(DateTime(timezone=True), primary_key=True, index=True)
     belief_horizon = Column(Interval(), nullable=False, primary_key=True)
-    cumulative_probability = Column(Float, nullable=False, primary_key=True)
+    cumulative_probability = Column(
+        Float, nullable=False, primary_key=True, default=0.5
+    )
     event_value = Column(Float, nullable=False)
 
     @declared_attr

--- a/timely_beliefs/tests/test_belief_query.py
+++ b/timely_beliefs/tests/test_belief_query.py
@@ -90,7 +90,7 @@ def test_query_belief_by_belief_time(
     ex_post_time_slot_sensor: DBSensor,
     day_ahead_belief_about_ex_post_time_slot_event: DBTimedBelief,
 ):
-    belief_df = DBTimedBelief.query(
+    belief_df = DBTimedBelief.query_all(
         session=session,
         sensor=ex_post_time_slot_sensor,
         belief_before=datetime(2018, 1, 1, 13, tzinfo=utc),
@@ -112,7 +112,7 @@ def test_query_belief_by_belief_time(
     # No beliefs a year earlier
     assert (
         len(
-            DBTimedBelief.query(
+            DBTimedBelief.query_all(
                 session=session,
                 sensor=ex_post_time_slot_sensor,
                 belief_before=datetime(2017, 1, 1, 10, tzinfo=utc),
@@ -124,7 +124,7 @@ def test_query_belief_by_belief_time(
     # No beliefs 2 months later
     assert (
         len(
-            DBTimedBelief.query(
+            DBTimedBelief.query_all(
                 session=session,
                 sensor=ex_post_time_slot_sensor,
                 belief_not_before=datetime(2018, 1, 3, 10, tzinfo=utc),
@@ -136,7 +136,7 @@ def test_query_belief_by_belief_time(
     # One belief after 10am UTC
     assert (
         len(
-            DBTimedBelief.query(
+            DBTimedBelief.query_all(
                 session=session,
                 sensor=ex_post_time_slot_sensor,
                 belief_not_before=datetime(2018, 1, 1, 10, tzinfo=utc),
@@ -148,7 +148,7 @@ def test_query_belief_by_belief_time(
     # No beliefs an hour earlier
     assert (
         len(
-            DBTimedBelief.query(
+            DBTimedBelief.query_all(
                 session=session,
                 sensor=ex_post_time_slot_sensor,
                 belief_before=datetime(2018, 1, 1, 9, tzinfo=utc),
@@ -160,7 +160,7 @@ def test_query_belief_by_belief_time(
     # No beliefs after 1pm UTC
     assert (
         len(
-            DBTimedBelief.query(
+            DBTimedBelief.query_all(
                 session=session,
                 sensor=ex_post_time_slot_sensor,
                 belief_not_before=datetime(2018, 1, 1, 13, tzinfo=utc),
@@ -174,7 +174,7 @@ def test_query_belief_history(
     ex_post_time_slot_sensor: DBSensor,
     multiple_day_ahead_beliefs_about_ex_post_time_slot_event: List[DBTimedBelief],
 ):
-    df = DBTimedBelief.query(session=session, sensor=ex_post_time_slot_sensor)
+    df = DBTimedBelief.query_all(session=session, sensor=ex_post_time_slot_sensor)
     event_start = datetime(2025, 1, 2, 22, 45, tzinfo=utc)
     df2 = df.belief_history(event_start).sort_index(
         level="belief_time", ascending=False
@@ -199,7 +199,7 @@ def test_query_rolling_horizon(
     time_slot_sensor: DBSensor, rolling_day_ahead_beliefs_about_time_slot_events
 ):
     # belief db selects all beliefs but one recent one (made exactly at 15h)
-    belief_df = DBTimedBelief.query(
+    belief_df = DBTimedBelief.query_all(
         session=session,
         sensor=time_slot_sensor,
         belief_before=datetime(2050, 1, 1, 15, tzinfo=utc),
@@ -222,7 +222,7 @@ def test_query_fixed_horizon(
     time_slot_sensor: DBSensor, rolling_day_ahead_beliefs_about_time_slot_events
 ):
     belief_time = datetime(2050, 1, 1, 11, tzinfo=utc)
-    df = DBTimedBelief.query(
+    df = DBTimedBelief.query_all(
         session=session,
         sensor=time_slot_sensor,
         belief_before=datetime(2050, 1, 1, 15, tzinfo=utc),
@@ -242,7 +242,7 @@ def test_query_fixed_horizon(
 def test_downsample(time_slot_sensor, rolling_day_ahead_beliefs_about_time_slot_events):
     """Downsample from 15 minutes to 2 hours."""
     new_resolution = timedelta(hours=2)
-    belief_df = DBTimedBelief.query(
+    belief_df = DBTimedBelief.query_all(
         session=session,
         sensor=time_slot_sensor,
         belief_before=datetime(2100, 1, 1, 13, tzinfo=utc),
@@ -255,7 +255,7 @@ def test_downsample(time_slot_sensor, rolling_day_ahead_beliefs_about_time_slot_
 def test_upsample(time_slot_sensor, rolling_day_ahead_beliefs_about_time_slot_events):
     """Upsample from 15 minutes to 5 minutes."""
     new_resolution = timedelta(minutes=5)
-    belief_df = DBTimedBelief.query(
+    belief_df = DBTimedBelief.query_all(
         session=session,
         sensor=time_slot_sensor,
         belief_before=datetime(2100, 1, 1, 13, tzinfo=utc),
@@ -267,7 +267,7 @@ def test_upsample(time_slot_sensor, rolling_day_ahead_beliefs_about_time_slot_ev
 
 def _test_empty_frame(time_slot_sensor):
     """ pandas GH30517 """
-    bdf = DBTimedBelief.query(
+    bdf = DBTimedBelief.query_all(
         session=session,
         sensor=time_slot_sensor,
         belief_before=datetime(1900, 1, 1, 13, tzinfo=utc),

--- a/timely_beliefs/tests/test_belief_query.py
+++ b/timely_beliefs/tests/test_belief_query.py
@@ -219,14 +219,17 @@ def test_query_rolling_horizon(
 
 
 def test_query_fixed_horizon(
-    time_slot_sensor: DBSensor, rolling_day_ahead_beliefs_about_time_slot_events
+    time_slot_sensor: DBSensor,
+    rolling_day_ahead_beliefs_about_time_slot_events,
+    test_source_a,
+    test_source_b,
 ):
     belief_time = datetime(2050, 1, 1, 11, tzinfo=utc)
     df = DBTimedBelief.search_session(
         session=session,
         sensor=time_slot_sensor,
         belief_before=datetime(2050, 1, 1, 15, tzinfo=utc),
-        source=[1, 2],
+        source=[test_source_a, test_source_b],
     )
     df2 = df.fixed_viewpoint(belief_time=belief_time)
     assert len(df2) == 2

--- a/timely_beliefs/tests/test_belief_query.py
+++ b/timely_beliefs/tests/test_belief_query.py
@@ -90,7 +90,7 @@ def test_query_belief_by_belief_time(
     ex_post_time_slot_sensor: DBSensor,
     day_ahead_belief_about_ex_post_time_slot_event: DBTimedBelief,
 ):
-    belief_df = DBTimedBelief.query_all(
+    belief_df = DBTimedBelief.search_session(
         session=session,
         sensor=ex_post_time_slot_sensor,
         belief_before=datetime(2018, 1, 1, 13, tzinfo=utc),
@@ -112,7 +112,7 @@ def test_query_belief_by_belief_time(
     # No beliefs a year earlier
     assert (
         len(
-            DBTimedBelief.query_all(
+            DBTimedBelief.search_session(
                 session=session,
                 sensor=ex_post_time_slot_sensor,
                 belief_before=datetime(2017, 1, 1, 10, tzinfo=utc),
@@ -124,7 +124,7 @@ def test_query_belief_by_belief_time(
     # No beliefs 2 months later
     assert (
         len(
-            DBTimedBelief.query_all(
+            DBTimedBelief.search_session(
                 session=session,
                 sensor=ex_post_time_slot_sensor,
                 belief_not_before=datetime(2018, 1, 3, 10, tzinfo=utc),
@@ -136,7 +136,7 @@ def test_query_belief_by_belief_time(
     # One belief after 10am UTC
     assert (
         len(
-            DBTimedBelief.query_all(
+            DBTimedBelief.search_session(
                 session=session,
                 sensor=ex_post_time_slot_sensor,
                 belief_not_before=datetime(2018, 1, 1, 10, tzinfo=utc),
@@ -148,7 +148,7 @@ def test_query_belief_by_belief_time(
     # No beliefs an hour earlier
     assert (
         len(
-            DBTimedBelief.query_all(
+            DBTimedBelief.search_session(
                 session=session,
                 sensor=ex_post_time_slot_sensor,
                 belief_before=datetime(2018, 1, 1, 9, tzinfo=utc),
@@ -160,7 +160,7 @@ def test_query_belief_by_belief_time(
     # No beliefs after 1pm UTC
     assert (
         len(
-            DBTimedBelief.query_all(
+            DBTimedBelief.search_session(
                 session=session,
                 sensor=ex_post_time_slot_sensor,
                 belief_not_before=datetime(2018, 1, 1, 13, tzinfo=utc),
@@ -174,7 +174,7 @@ def test_query_belief_history(
     ex_post_time_slot_sensor: DBSensor,
     multiple_day_ahead_beliefs_about_ex_post_time_slot_event: List[DBTimedBelief],
 ):
-    df = DBTimedBelief.query_all(session=session, sensor=ex_post_time_slot_sensor)
+    df = DBTimedBelief.search_session(session=session, sensor=ex_post_time_slot_sensor)
     event_start = datetime(2025, 1, 2, 22, 45, tzinfo=utc)
     df2 = df.belief_history(event_start).sort_index(
         level="belief_time", ascending=False
@@ -199,7 +199,7 @@ def test_query_rolling_horizon(
     time_slot_sensor: DBSensor, rolling_day_ahead_beliefs_about_time_slot_events
 ):
     # belief db selects all beliefs but one recent one (made exactly at 15h)
-    belief_df = DBTimedBelief.query_all(
+    belief_df = DBTimedBelief.search_session(
         session=session,
         sensor=time_slot_sensor,
         belief_before=datetime(2050, 1, 1, 15, tzinfo=utc),
@@ -222,7 +222,7 @@ def test_query_fixed_horizon(
     time_slot_sensor: DBSensor, rolling_day_ahead_beliefs_about_time_slot_events
 ):
     belief_time = datetime(2050, 1, 1, 11, tzinfo=utc)
-    df = DBTimedBelief.query_all(
+    df = DBTimedBelief.search_session(
         session=session,
         sensor=time_slot_sensor,
         belief_before=datetime(2050, 1, 1, 15, tzinfo=utc),
@@ -242,7 +242,7 @@ def test_query_fixed_horizon(
 def test_downsample(time_slot_sensor, rolling_day_ahead_beliefs_about_time_slot_events):
     """Downsample from 15 minutes to 2 hours."""
     new_resolution = timedelta(hours=2)
-    belief_df = DBTimedBelief.query_all(
+    belief_df = DBTimedBelief.search_session(
         session=session,
         sensor=time_slot_sensor,
         belief_before=datetime(2100, 1, 1, 13, tzinfo=utc),
@@ -255,7 +255,7 @@ def test_downsample(time_slot_sensor, rolling_day_ahead_beliefs_about_time_slot_
 def test_upsample(time_slot_sensor, rolling_day_ahead_beliefs_about_time_slot_events):
     """Upsample from 15 minutes to 5 minutes."""
     new_resolution = timedelta(minutes=5)
-    belief_df = DBTimedBelief.query_all(
+    belief_df = DBTimedBelief.search_session(
         session=session,
         sensor=time_slot_sensor,
         belief_before=datetime(2100, 1, 1, 13, tzinfo=utc),
@@ -267,7 +267,7 @@ def test_upsample(time_slot_sensor, rolling_day_ahead_beliefs_about_time_slot_ev
 
 def _test_empty_frame(time_slot_sensor):
     """ pandas GH30517 """
-    bdf = DBTimedBelief.query_all(
+    bdf = DBTimedBelief.search_session(
         session=session,
         sensor=time_slot_sensor,
         belief_before=datetime(1900, 1, 1, 13, tzinfo=utc),

--- a/timely_beliefs/tests/test_db_subclassing.py
+++ b/timely_beliefs/tests/test_db_subclassing.py
@@ -5,7 +5,7 @@ from sqlalchemy import Column, Float, ForeignKey, Integer
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import backref, relationship
 
-from timely_beliefs import DBBeliefSource, DBSensor
+from timely_beliefs import BeliefsDataFrame, DBBeliefSource, DBSensor
 from timely_beliefs.beliefs.classes import TimedBeliefDBMixin
 from timely_beliefs.db_base import Base
 from timely_beliefs.sources.classes import BeliefSourceDBMixin
@@ -137,5 +137,7 @@ def test_custom_source_and_beliefs_with_mixin(db):
     assert "my_belief_source" in db.tables.keys()
     assert "my_timed_belief" in db.tables.keys()
 
+    # todo: adjust test for deprecated query method
     bdf = JoyfulBeliefInCustomTable.query(session, sensor)
+    assert isinstance(bdf, BeliefsDataFrame)
     assert len(bdf) == 1

--- a/timely_beliefs/tests/test_db_subclassing.py
+++ b/timely_beliefs/tests/test_db_subclassing.py
@@ -136,3 +136,6 @@ def test_custom_source_and_beliefs_with_mixin(db):
 
     assert "my_belief_source" in db.tables.keys()
     assert "my_timed_belief" in db.tables.keys()
+
+    bdf = JoyfulBeliefInCustomTable.query(session, sensor)
+    assert len(bdf) == 1

--- a/timely_beliefs/tests/test_db_subclassing.py
+++ b/timely_beliefs/tests/test_db_subclassing.py
@@ -5,6 +5,7 @@ from sqlalchemy import Column, Float, ForeignKey, Integer
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import backref, relationship
 
+import timely_beliefs.utils as tb_utils
 from timely_beliefs import BeliefsDataFrame, DBBeliefSource, DBSensor
 from timely_beliefs.beliefs.classes import TimedBeliefDBMixin
 from timely_beliefs.db_base import Base
@@ -91,11 +92,8 @@ class JoyfulBeliefInCustomTable(Base, TimedBeliefDBMixin):
     ):
         self.happiness = happiness
         TimedBeliefDBMixin.__init__(self, sensor, source, **kwargs)
-        [
-            kwargs.pop(key, None)
-            for key in TimedBeliefDBMixin.__init__.__code__.co_varnames
-        ]  # take out any kwargs used by the mixin, and pass on any remaining kwargs to the next super class.
-        Base.__init__(self, **kwargs)
+        base_kwargs = tb_utils.remove_class_init_kwargs(TimedBeliefDBMixin, kwargs)
+        Base.__init__(self, **base_kwargs)
 
 
 def test_custom_source_and_beliefs_with_mixin(db):

--- a/timely_beliefs/tests/test_utils.py
+++ b/timely_beliefs/tests/test_utils.py
@@ -1,0 +1,11 @@
+from timely_beliefs.utils import remove_class_init_kwargs
+
+
+def test_remove_used_kwargs():
+    class MyCls:
+        def __init__(self, a, b):
+            pass
+
+    kwargs = dict(a=1, b=2, c=3, d=4, self=5)
+    remaining_kwargs = remove_class_init_kwargs(MyCls, kwargs)
+    assert remaining_kwargs == dict(c=3, d=4, self=5)

--- a/timely_beliefs/utils.py
+++ b/timely_beliefs/utils.py
@@ -188,3 +188,12 @@ def replace_deprecated_argument(
         )
         new_arg_val = deprecated_arg_val
     return new_arg_val
+
+
+def remove_class_init_kwargs(cls, kwargs: dict) -> dict:
+    """Remove kwargs used to initialize the given class."""
+    params = list(cls.__init__.__code__.co_varnames)
+    params.remove("self")
+    for param in params:
+        kwargs.pop(param, None)
+    return kwargs

--- a/timely_beliefs/utils.py
+++ b/timely_beliefs/utils.py
@@ -1,6 +1,6 @@
+import warnings
 from datetime import datetime, timedelta
 from typing import Optional, Sequence, Union
-import warnings
 
 import pandas as pd
 
@@ -153,3 +153,14 @@ def replace_multi_index_level(
         # Replace the index
         df.index = mux
     return df.sort_index()
+
+
+def append_doc_of(fun):
+    def decorator(f):
+        if f.__doc__:
+            f.__doc__ += fun.__doc__
+        else:
+            f.__doc__ = fun.__doc__
+        return f
+
+    return decorator

--- a/timely_beliefs/utils.py
+++ b/timely_beliefs/utils.py
@@ -78,11 +78,11 @@ def all_of_type(seq: Sequence, element_type) -> bool:
 
 
 def replace_multi_index_level(
-    df: "classes.BeliefsDataFrame",
+    df: "classes.BeliefsDataFrame",  # noqa: F821
     level: str,
     index: pd.Index,
-    intersection: bool = False,  # noqa: F821
-) -> "classes.BeliefsDataFrame":
+    intersection: bool = False,
+) -> "classes.BeliefsDataFrame":  # noqa: F821
     """Replace one of the index levels of the multi-indexed DataFrame. Returns a new DataFrame object.
     :param df: a BeliefsDataFrame (or just a multi-indexed DataFrame).
     :param level: the name of the index level to replace.
@@ -164,3 +164,27 @@ def append_doc_of(fun):
         return f
 
     return decorator
+
+
+def replace_deprecated_argument(
+    deprecated_arg_name: str,
+    deprecated_arg_val: any,
+    new_arg_name: str,
+    new_arg_val: any,
+) -> any:
+    """Util function for replacing a deprecated argument in favour of a new argument.
+    If new_arg_val was not already set, it is set to deprecated_arg_val together with a FutureWarning.
+    """
+    if new_arg_val is None and deprecated_arg_val is None:
+        raise ValueError(f"Missing argument: {new_arg_name}.")
+    elif new_arg_val is not None:
+        pass
+    else:
+        import warnings
+
+        warnings.warn(
+            f"Argument '{deprecated_arg_name}' will be replaced by '{new_arg_name}'. Replace '{deprecated_arg_name}' with '{new_arg_name}' to suppress this warning.",
+            FutureWarning,
+        )
+        new_arg_val = deprecated_arg_val
+    return new_arg_val


### PR DESCRIPTION
Several improvements to the TimedBeliefDBMixin, including:

- New method to persist TimedBelief objects from a BeliefsDataFrame
- Set default table indices
- Set default cumulative probability
- Rename query method to prevent clashing with SQLAlchemy