### PR TITLE
Enhance read csv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "uncertainty",
         "lineage",
     ],
-    version="1.3.0",
+    version="1.3.1",
     install_requires=[
         "pytz",
         "pandas>=1.1.5",

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -477,6 +477,7 @@ def read_csv(
     sensor: "classes.Sensor",
     source: "classes.BeliefSource" = None,
     look_up_sources: List["classes.BeliefSource"] = None,
+    **kwargs,
 ) -> "classes.BeliefsDataFrame":
     """Utility function to load a BeliefsDataFrame from a csv file (see example/temperature.csv).
 
@@ -489,7 +490,7 @@ def read_csv(
     >>> df.to_csv()
 
     """
-    df = pd.read_csv(path)
+    df = pd.read_csv(path, **kwargs)
     if source is not None:
         df["source"] = source_utils.ensure_source_exists(source)
     elif "source" in df.columns:

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -488,6 +488,13 @@ def read_csv(
     In case the csv file contains multiple source names, you can pass a list of sources.
     Each source name will be replaced by the actual source.
 
+    Also supports the case of a csv file with just 2 columns and 1 header row (a quite common time series format).
+    In this case no special header names are required, but the first column has to contain the UTC event starts,
+    and the second column has to contain the event values.
+    You also need to pass explicit values for the belief horizon/time and cumulative probability,
+    in addition to the sensor and source.
+    Useful ddditional kwargs passed to pandas are parse_dates=True and infer_datetime_format=True.
+
     To write a BeliefsDataFrame to a csv file, just use the pandas way:
 
     >>> df.to_csv()


### PR DESCRIPTION
Add support to read in a simple time series (two columns) from CSV, provided the caller passes a source and belief time/horizon explicitly (besides the sensor). Not sure if using `len(df.columns) == 2` is the best way to distinguish this (arguably common) data format. Should I rather add an explicit boolean option to the function?