### PR TITLE
Fix deprecation warnings for unused optional arguments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "uncertainty",
         "lineage",
     ],
-    version="1.4.1",
+    version="1.4.2",
     python_requires=">=3.6.1",  # not enforced, just info
     install_requires=[
         "pytz",

--- a/timely_beliefs/utils.py
+++ b/timely_beliefs/utils.py
@@ -178,7 +178,7 @@ def replace_deprecated_argument(
     """
     if required_argument is True and new_arg_val is None and deprecated_arg_val is None:
         raise ValueError(f"Missing argument: {new_arg_name}.")
-    elif deprecated_arg_val is not None:
+    if deprecated_arg_val is not None:
         import warnings
 
         warnings.warn(

--- a/timely_beliefs/utils.py
+++ b/timely_beliefs/utils.py
@@ -176,11 +176,9 @@ def replace_deprecated_argument(
     """Util function for replacing a deprecated argument in favour of a new argument.
     If new_arg_val was not already set, it is set to deprecated_arg_val together with a FutureWarning.
     """
-    if required_argument and new_arg_val is None and deprecated_arg_val is None:
+    if required_argument is True and new_arg_val is None and deprecated_arg_val is None:
         raise ValueError(f"Missing argument: {new_arg_name}.")
-    elif new_arg_val is not None:
-        pass
-    else:
+    elif deprecated_arg_val is not None:
         import warnings
 
         warnings.warn(


### PR DESCRIPTION
Stop giving deprecation warnings for optional arguments that are not used.