### PR TITLE
Issue 80 filter by most recent events

### DIFF
--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -308,8 +308,9 @@ class TimedBeliefDBMixin(TimedBelief):
         belief_before: Optional[datetime] = None,  # deprecated
         belief_not_before: Optional[datetime] = None,  # deprecated
         source: Optional[Union[BeliefSource, List[BeliefSource]]] = None,
-        most_recent_only: bool = False,
+        most_recent_beliefs_only: bool = False,
         most_recent_events_only: bool = False,
+        most_recent_only: bool = False,  # deprecated
         place_beliefs_in_sensor_timezone: bool = True,
         place_events_in_sensor_timezone: bool = True,
     ) -> "BeliefsDataFrame":
@@ -323,7 +324,7 @@ class TimedBeliefDBMixin(TimedBelief):
         :param beliefs_after: only return beliefs formed after this datetime (inclusive)
         :param beliefs_before: only return beliefs formed before this datetime (inclusive)
         :param source: only return beliefs formed by the given source or list of sources
-        :param most_recent_only: only return the most recent beliefs for each event from each source (minimum belief horizon)
+        :param most_recent_beliefs_only: only return the most recent beliefs for each event from each source (minimum belief horizon)
         :param most_recent_events_only: only return (post knowledge time) beliefs for the most recent event (maximum event start)
         :param place_beliefs_in_sensor_timezone: if True (the default), belief times are converted to the timezone of the sensor
         :param place_events_in_sensor_timezone: if True (the default), event starts are converted to the timezone of the sensor
@@ -360,6 +361,14 @@ class TimedBeliefDBMixin(TimedBelief):
             belief_not_before,
             "beliefs_after",
             beliefs_after,
+            required_argument=False,
+        )
+        # todo: deprecate the 'most_recent_only' argument in favor of 'most_recent_beliefs_only' (announced v1.7.0)
+        most_recent_beliefs_only = tb_utils.replace_deprecated_argument(
+            "most_recent_only",
+            most_recent_only,
+            "most_recent_beliefs_only",
+            most_recent_beliefs_only,
             required_argument=False,
         )
 
@@ -433,7 +442,7 @@ class TimedBeliefDBMixin(TimedBelief):
             q = q.join(source_cls).filter(cls.source_id.in_([s.id for s in sources]))
 
         # Apply most recent beliefs filter
-        if most_recent_only:
+        if most_recent_beliefs_only:
             subq = (
                 session.query(
                     cls.event_start,

--- a/timely_beliefs/tests/test_belief_query.py
+++ b/timely_beliefs/tests/test_belief_query.py
@@ -305,6 +305,8 @@ def test_select_most_recent_deterministic_beliefs(
     multiple_day_ahead_beliefs_about_ex_post_time_slot_event: List[DBTimedBelief],
     multiple_day_after_beliefs_about_ex_post_time_slot_event: List[DBTimedBelief],
 ):
+    """Check db query filters for most recent beliefs, most recent events, and both at once."""
+
     # Query all beliefs for this sensor
     df = DBTimedBelief.search_session(
         session=session, sensor=ex_post_time_slot_sensor, most_recent_only=False
@@ -332,6 +334,23 @@ def test_select_most_recent_deterministic_beliefs(
     )
     pd.testing.assert_frame_equal(
         df_recent_events_within_query, df_recent_events_after_query
+    )
+
+    # Most recent beliefs and most recent events selected after query (our reference)
+    df_recent_both_after_query = df_recent_beliefs_after_query[
+        df_recent_beliefs_after_query.index.get_level_values("event_start")
+        == df_recent_beliefs_after_query.event_starts.max()
+    ]
+
+    # Most recent beliefs and most recent events selected within query (our test)
+    df_recent_both_within_query = DBTimedBelief.search_session(
+        session=session,
+        sensor=ex_post_time_slot_sensor,
+        most_recent_only=True,
+        most_recent_events_only=True,
+    )
+    pd.testing.assert_frame_equal(
+        df_recent_both_within_query, df_recent_both_after_query
     )
 
 

--- a/timely_beliefs/tests/test_belief_query.py
+++ b/timely_beliefs/tests/test_belief_query.py
@@ -81,6 +81,28 @@ def multiple_probabilistic_day_ahead_beliefs_about_ex_post_time_slot_event(
     return beliefs
 
 
+@pytest.fixture(scope="function")
+def multiple_day_after_beliefs_about_ex_post_time_slot_event(
+    ex_post_time_slot_sensor: DBSensor, test_source_a: DBBeliefSource
+):
+    """Define multiple day-after beliefs about an ex post time slot event."""
+    n = 10
+    event_start = datetime(2025, 1, 2, 23, 00, tzinfo=utc)
+    beliefs = []
+    for i in range(n):
+        belief = DBTimedBelief(
+            source=test_source_a,
+            sensor=ex_post_time_slot_sensor,
+            value=10 + i,
+            belief_time=ex_post_time_slot_sensor.knowledge_time(event_start)
+            + timedelta(hours=i + 1),
+            event_start=event_start,
+        )
+        session.add(belief)
+        beliefs.append(belief)
+    return beliefs
+
+
 def test_query_belief_by_belief_time(
     ex_post_time_slot_sensor: DBSensor,
     day_ahead_belief_about_ex_post_time_slot_event: DBTimedBelief,
@@ -281,15 +303,36 @@ def _test_empty_frame(time_slot_sensor):
 def test_select_most_recent_deterministic_beliefs(
     ex_post_time_slot_sensor: DBSensor,
     multiple_day_ahead_beliefs_about_ex_post_time_slot_event: List[DBTimedBelief],
+    multiple_day_after_beliefs_about_ex_post_time_slot_event: List[DBTimedBelief],
 ):
+    # Query all beliefs for this sensor
     df = DBTimedBelief.search_session(
         session=session, sensor=ex_post_time_slot_sensor, most_recent_only=False
     )
-    most_recent_df = belief_utils.select_most_recent_belief(df)
-    df = DBTimedBelief.search_session(
+
+    # Most recent beliefs selected after query (our reference)
+    df_recent_beliefs_after_query = belief_utils.select_most_recent_belief(df)
+
+    # Most recent beliefs selected within query (our test)
+    df_recent_beliefs_within_query = DBTimedBelief.search_session(
         session=session, sensor=ex_post_time_slot_sensor, most_recent_only=True
     )
-    pd.testing.assert_frame_equal(df, most_recent_df)
+    pd.testing.assert_frame_equal(
+        df_recent_beliefs_within_query, df_recent_beliefs_after_query
+    )
+
+    # Most recent events selected after query (our reference)
+    df_recent_events_after_query = df[
+        df.index.get_level_values("event_start") == df.event_starts.max()
+    ]
+
+    # Most recent events selected within query (our test)
+    df_recent_events_within_query = DBTimedBelief.search_session(
+        session=session, sensor=ex_post_time_slot_sensor, most_recent_events_only=True
+    )
+    pd.testing.assert_frame_equal(
+        df_recent_events_within_query, df_recent_events_after_query
+    )
 
 
 def test_select_most_recent_probabilistic_beliefs(


### PR DESCRIPTION
I do need to adjust some terms I use in tests, but I prefer to do that in a separate PR together with some other ill-named tests and test variables, so this PR focuses on adding functionality only. For example, the "day-after" beliefs are indeed after the fact, but actually on the same day as knowledge time, which is too confusing in the long run. So please consider "day-after" here as just a name to set it apart from "day-ahead".