### PR TITLE
Allow passing sensor ids

### DIFF
--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -324,7 +324,7 @@ class TimedBeliefDBMixin(TimedBelief):
         The optional arguments represent optional filters.
         :param session: the database session to use
         :param sensor: sensor to which the beliefs pertain, or its unique sensor id
-        :param sensor_class: optionally pass the sensor (sub)class explicitly (only needed if you pass a sensor id and not a sensor); the class should be mapped to a database table
+        :param sensor_class: optionally pass the sensor (sub)class explicitly (only needed if you pass a sensor id instead of a sensor, and your sensor class is not DBSensor); the class should be mapped to a database table
         :param event_starts_after: only return beliefs about events that start after this datetime (inclusive)
         :param event_ends_before: only return beliefs about events that end before this datetime (inclusive)
         :param beliefs_after: only return beliefs formed after this datetime (inclusive)

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -405,20 +405,15 @@ class TimedBeliefDBMixin(TimedBelief):
                 raise ValueError("No such sensor")
         elif not isinstance(sensor, SensorDBMixin):
             raise ValueError(f"sensor {sensor} is not a {SensorDBMixin}")
-        event_resolution, knowledge_horizon_fnc, knowledge_horizon_par = (
-            sensor.event_resolution,
-            sensor.knowledge_horizon_fnc,
-            sensor.knowledge_horizon_par,
-        )
 
         # Get bounds on the knowledge horizon (so we can already roughly filter by belief time)
         (
             knowledge_horizon_min,
             knowledge_horizon_max,
         ) = sensor_utils.eval_verified_knowledge_horizon_fnc(
-            knowledge_horizon_fnc,
-            knowledge_horizon_par,
-            event_resolution=event_resolution,
+            sensor.knowledge_horizon_fnc,
+            sensor.knowledge_horizon_par,
+            event_resolution=sensor.event_resolution,
             get_bounds=True,
         )
 
@@ -429,7 +424,7 @@ class TimedBeliefDBMixin(TimedBelief):
         if event_starts_after is not None:
             q = q.filter(cls.event_start >= event_starts_after)
         if event_ends_before is not None:
-            q = q.filter(cls.event_start + event_resolution <= event_ends_before)
+            q = q.filter(cls.event_start + sensor.event_resolution <= event_ends_before)
 
         # Apply rough belief time filter
         if beliefs_after is not None:

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -324,7 +324,7 @@ class TimedBeliefDBMixin(TimedBelief):
         The optional arguments represent optional filters.
         :param session: the database session to use
         :param sensor: sensor to which the beliefs pertain, or its unique sensor id
-        :param sensor_class: optionally pass the sensor (sub)class explicitly (it should be mapped to a database table)
+        :param sensor_class: optionally pass the sensor (sub)class explicitly (only needed if you pass a sensor id and not a sensor); the class should be mapped to a database table
         :param event_starts_after: only return beliefs about events that start after this datetime (inclusive)
         :param event_ends_before: only return beliefs about events that end before this datetime (inclusive)
         :param beliefs_after: only return beliefs formed after this datetime (inclusive)

--- a/timely_beliefs/tests/test_belief_query.py
+++ b/timely_beliefs/tests/test_belief_query.py
@@ -313,7 +313,7 @@ def test_search_by_sensor_id(
 
     # Query all beliefs for this sensor, using sensor id (our test)
     df_by_id = DBTimedBelief.search_session(
-        session=session, sensor=ex_post_time_slot_sensor, most_recent_only=False
+        session=session, sensor=ex_post_time_slot_sensor.id, most_recent_only=False
     )
     assert not df_by_id.empty
     pd.testing.assert_frame_equal(df_by_id, df_by_instance)

--- a/timely_beliefs/tests/test_belief_query.py
+++ b/timely_beliefs/tests/test_belief_query.py
@@ -300,6 +300,25 @@ def _test_empty_frame(time_slot_sensor):
     )  # dtype of belief_horizon is timedelta64[ns], so the minimum horizon on an empty BeliefsDataFrame is NaT instead of NaN
 
 
+def test_search_by_sensor_id(
+    ex_post_time_slot_sensor: DBSensor,
+    multiple_day_ahead_beliefs_about_ex_post_time_slot_event: List[DBTimedBelief],
+):
+    """Check db query by sensor id, against query by sensor instance, for a non-empty dataset."""
+
+    # Query all beliefs for this sensor, using sensor instance (our reference)
+    df_by_instance = DBTimedBelief.search_session(
+        session=session, sensor=ex_post_time_slot_sensor, most_recent_only=False
+    )
+
+    # Query all beliefs for this sensor, using sensor id (our test)
+    df_by_id = DBTimedBelief.search_session(
+        session=session, sensor=ex_post_time_slot_sensor, most_recent_only=False
+    )
+    assert not df_by_id.empty
+    pd.testing.assert_frame_equal(df_by_id, df_by_instance)
+
+
 def test_select_most_recent_deterministic_beliefs(
     ex_post_time_slot_sensor: DBSensor,
     multiple_day_ahead_beliefs_about_ex_post_time_slot_event: List[DBTimedBelief],


### PR DESCRIPTION
And if you pass a sensor instance instead, the query that was there before was actually not needed.