### PR TITLE
Officially support Python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Add Python 3.9 classifier. I think our badge should update itself when we release a new version to pypi.