### PR TITLE
Allow passing custom join targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The data model is an extended [pandas](https://pandas.pydata.org/) DataFrame tha
 Getting started (or try one of the [other ways to create a BeliefsDataFrame](timely_beliefs/docs/init.md)):
 
     >>> import timely_beliefs as tb
-    >>> bdf = tb.BeliefsDataFrame([tb.TimedBelief(tb.Sensor("Indoor temperature", "°C"), tb.BeliefSource("Thermometer"), 21, event_time="2000-03-05 11:00Z", belief_horizon="0H")])
-    >>> print(bdf)
+    >>> df = tb.BeliefsDataFrame([tb.TimedBelief(tb.Sensor("Indoor temperature", "°C"), tb.BeliefSource("Thermometer"), 21, event_time="2000-03-05 11:00Z", belief_horizon="0H")])
+    >>> print(df)
                                                                                             event_value
     event_start               belief_time               source      cumulative_probability             
     2000-03-05 11:00:00+00:00 2000-03-05 11:00:00+00:00 Thermometer 0.5                              21

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -326,12 +326,14 @@ class TimedBeliefDBMixin(TimedBelief):
         most_recent_only: bool = False,  # deprecated
         place_beliefs_in_sensor_timezone: bool = True,
         place_events_in_sensor_timezone: bool = True,
-        custom_filter_criteria: List[BinaryExpression] = None,
-        custom_join_targets: List[JoinTarget] = None,
+        custom_filter_criteria: Optional[List[BinaryExpression]] = None,
+        custom_join_targets: Optional[List[JoinTarget]] = None,
     ) -> "BeliefsDataFrame":
         """Search a database session for beliefs about sensor events.
 
-        The optional arguments represent optional filters.
+        The optional arguments represent optional filters, with two exceptions:
+        - sensor_class makes it possible to create a query on sensor subclasses
+        - custom_join_targets makes it possible to add custom filters using other (incl. subclassed) targets
         :param session: the database session to use
         :param sensor: sensor to which the beliefs pertain, or its unique sensor id
         :param sensor_class: optionally pass the sensor (sub)class explicitly (only needed if you pass a sensor id instead of a sensor, and your sensor class is not DBSensor); the class should be mapped to a database table
@@ -346,8 +348,8 @@ class TimedBeliefDBMixin(TimedBelief):
         :param most_recent_events_only: only return (post knowledge time) beliefs for the most recent event (maximum event start)
         :param place_beliefs_in_sensor_timezone: if True (the default), belief times are converted to the timezone of the sensor
         :param place_events_in_sensor_timezone: if True (the default), event starts are converted to the timezone of the sensor
-        :param custom_filter_criteria: optionally pass additional filters, such as ones that rely on subclasses
-        :param custom_join_targets: optionally pass additional join targets, to accommodate filters that rely on subclasses
+        :param custom_filter_criteria: additional filters, such as ones that rely on subclasses
+        :param custom_join_targets: additional join targets, to accommodate filters that rely on other targets (e.g. subclasses)
         :returns: a multi-index DataFrame with all relevant beliefs
         """
 

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -1,7 +1,7 @@
 import math
+import types
 from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
-import types
 
 import altair as alt
 import pandas as pd

--- a/timely_beliefs/docs/db.md
+++ b/timely_beliefs/docs/db.md
@@ -140,7 +140,7 @@ This one uses a Mixin class called `TimedBeliefDBMixin` (which is also used in t
             Base.__init__(self)
 
 
-Note that we don say where the sqlalchemy `Base` comes from here. This is the one from your project.
+Note that we don't say where the sqlalchemy `Base` comes from here. This is the one from your project.
 If you create tables from timely_belief's Base (see above) as well, you end up with more tables that you probably want to use.
 Which is not a blocker, but for cleanliness you might want to get all tables from timely beliefs base or define all Table implementations yourself, such as with `JoyfulBeliefInCustomTable` above.
 

--- a/timely_beliefs/docs/db.md
+++ b/timely_beliefs/docs/db.md
@@ -5,6 +5,7 @@
 1. [Derived database classes](#derived-database-classes)
 1. [Table creation and session](#table-creation-and-session)
 1. [Subclassing](#subclassing)
+1. [Queries](#queries)
 
 ## Derived database classes
 
@@ -142,3 +143,25 @@ This one uses a Mixin class called `TimedBeliefDBMixin` (which is also used in t
 Note that we don say where the sqlalchemy `Base` comes from here. This is the one from your project.
 If you create tables from timely_belief's Base (see above) as well, you end up with more tables that you probably want to use.
 Which is not a blocker, but for cleanliness you might want to get all tables from timely beliefs base or define all Table implementations yourself, such as with `JoyfulBeliefInCustomTable` above.
+
+### Queries
+
+The `search_session` method on the `TimedBeliefDBMixin` provides support for custom filters that rely on other database classes.
+
+For example, to continue the 1st example in [Subclassing](#subclassing), pass a custom `sensor_class` and `custom_filter_criteria` to filter on the `DBLocatedSensor`'s `location_name` attribute:
+
+    from timely_beliefs import DBTimedBelief
+    
+    df = DBTimedBelief.search_session(
+        sensor_class=DBLocatedSensor,
+        custom_filter_criteria=[DBLocatedSensor.location_name == "office"],
+    )
+
+Or for filters that rely on other (non-timely-beliefs) classes, use `custom_join_targets`.
+here, we assume a hypothetical custom class `Country` is referenced from the `DBLocatedSensor` class:
+
+    df = DBTimedBelief.search_session(
+        sensor_class=DBLocatedSensor,
+        custom_filter_criteria=[DBLocatedSensor.country_id == Country.id],
+        custom_join_targets=[Country],
+    )


### PR DESCRIPTION
Some warnings from FlexMeasures tests lead to this work. When applying custom filter criteria, it may be desired (or even necessary) to add additional `join` targets to the query. For example, when passing custom source filters using the subclassed `DataSource`:

> `SAWarning: SELECT statement has a cartesian product between FROM element(s) "timed_belief" and FROM element "data_source".  Apply join condition(s) between each element to resolve.`

This PR lets you pass custom join targets to the timely-beliefs query.