### PR TITLE
Define trivial probabilistic depth of empty frames as 1

### DIFF
--- a/timely_beliefs/beliefs/__init__.py
+++ b/timely_beliefs/beliefs/__init__.py
@@ -156,5 +156,9 @@ class BeliefsAccessor(object):
           skew normal = 3
              quartile = 3
           percentile = 99
+
+        Empty frames default to 1.
         """
+        if len(self._obj) == 0:
+            return 1
         return len(self._obj) / float(self.number_of_beliefs)


### PR DESCRIPTION
Avoid division by zero.