### PR TITLE
Propagate beliefs

### DIFF
--- a/timely_beliefs/__init__.py
+++ b/timely_beliefs/__init__.py
@@ -15,7 +15,7 @@ from timely_beliefs.beliefs.classes import (
     TimedBelief,
     TimedBeliefDBMixin,
 )
-from timely_beliefs.beliefs.utils import load_time_series, read_csv
+from timely_beliefs.beliefs.utils import load_time_series, read_csv, propagate_beliefs
 from timely_beliefs.examples import beliefs_data_frames
 
 

--- a/timely_beliefs/beliefs/__init__.py
+++ b/timely_beliefs/beliefs/__init__.py
@@ -43,8 +43,6 @@ class BeliefsAccessor(object):
             raise AttributeError("Must have index level 'source'.")
         if "cumulative_probability" not in obj.index.names:
             raise AttributeError("Must have index level 'cumulative_probability'.")
-        if "event_value" not in obj.columns:
-            raise AttributeError("Must have column 'event_value'.")
 
     @property
     def events(self) -> List[int]:

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -154,7 +154,7 @@ def propagate_beliefs(
 ) -> "classes.BeliefsDataFrame":
     """Propagate beliefs over time.
 
-    Requires deterministic data from a single source.
+    Requires deterministic data.
     """
     if df.lineage.probabilistic_depth != 1:
         raise NotImplementedError(

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -149,6 +149,24 @@ def respect_event_resolution(grouper: DataFrameGroupBy, resolution):
     return df
 
 
+def propagate_beliefs(
+    df: "classes.BeliefsDataFrame",
+) -> "classes.BeliefsDataFrame":
+    """Propagate beliefs over time.
+
+    Requires deterministic data from a single source.
+    """
+    if df.lineage.number_of_sources > 1:
+        raise NotImplementedError(
+            "Propagating multi-sourced beliefs is not yet implemented. Please file a GitHub issue."
+        )
+    if df.lineage.probabilistic_depth != 1:
+        raise NotImplementedError(
+            "Propagating probabilistic beliefs is not yet implemented. Please file a GitHub issue."
+        )
+    return df.groupby(level="event_start").ffill()
+
+
 def align_belief_times(
     slice: "classes.BeliefsDataFrame", unique_belief_times
 ) -> "classes.BeliefsDataFrame":

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -152,9 +152,28 @@ def respect_event_resolution(grouper: DataFrameGroupBy, resolution):
 def propagate_beliefs(
     df: "classes.BeliefsDataFrame",
 ) -> "classes.BeliefsDataFrame":
-    """Propagate beliefs over time.
+    """Propagate beliefs over time by filling NaN values.
 
+    We do this by assuming beliefs propagate over time (ceteris paribus, you still believe what you believed before).
+    That is, the most recent belief about an event is valid until a new belief is formed.
+    If no previous belief has been formed for a certain event, the original NaN valued row will be kept.
     Requires deterministic data.
+
+    For example:
+
+                                                                                          temp_air  wind_speed  cloud_cover
+    event_start               belief_time               source    cumulative_probability
+    2022-07-01 02:00:00+02:00 2022-06-30 15:10:30+02:00 simulator 0.5                          NaN         NaN         0.94
+                              2022-07-01 01:10:41+02:00 simulator 0.5                        13.61         NaN          NaN
+                              2022-07-01 02:10:32+02:00 simulator 0.5                          NaN        2.88          NaN
+
+    Becomes:
+
+                                                                                          temp_air  wind_speed  cloud_cover
+    event_start               belief_time               source    cumulative_probability
+    2022-07-01 02:00:00+02:00 2022-06-30 15:10:30+02:00 simulator 0.5                          NaN         NaN         0.94
+                              2022-07-01 01:10:41+02:00 simulator 0.5                        13.61         NaN         0.94
+                              2022-07-01 02:10:32+02:00 simulator 0.5                        13.61        2.88         0.94
     """
     if df.lineage.probabilistic_depth != 1:
         raise NotImplementedError(
@@ -166,10 +185,10 @@ def propagate_beliefs(
 def align_belief_times(
     slice: "classes.BeliefsDataFrame", unique_belief_times
 ) -> "classes.BeliefsDataFrame":
-    """Align belief times such that each event has the same set of unique belief times. We do this by assuming beliefs
-    propagate over time (ceteris paribus, you still believe what you believed before).
-    The most recent belief about an event is valid until a new belief is formed.
-    If no previous belief has been formed, a row is still explicitly included with a nan value.
+    """Align belief times such that each event has the same set of unique belief times.
+    We do this by assuming beliefs propagate over time (ceteris paribus, you still believe what you believed before).
+    That is, the most recent belief about an event is valid until a new belief is formed.
+    If no previous belief has been formed, a row is still explicitly included with a NaN value.
     The input BeliefsDataFrame should represent beliefs about a single event formed by a single source.
     """
 

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -156,15 +156,11 @@ def propagate_beliefs(
 
     Requires deterministic data from a single source.
     """
-    if df.lineage.number_of_sources > 1:
-        raise NotImplementedError(
-            "Propagating multi-sourced beliefs is not yet implemented. Please file a GitHub issue."
-        )
     if df.lineage.probabilistic_depth != 1:
         raise NotImplementedError(
             "Propagating probabilistic beliefs is not yet implemented. Please file a GitHub issue."
         )
-    return df.groupby(level="event_start").ffill()
+    return df.groupby(level=["event_start", "source"]).ffill()
 
 
 def align_belief_times(

--- a/timely_beliefs/tests/test_belief_utils.py
+++ b/timely_beliefs/tests/test_belief_utils.py
@@ -1,8 +1,8 @@
 import pandas as pd
 
-from timely_beliefs.examples import get_example_df
 from timely_beliefs.beliefs.probabilistic_utils import get_median_belief
 from timely_beliefs.beliefs.utils import propagate_beliefs
+from timely_beliefs.examples import get_example_df
 
 
 def test_propagate_multi_sourced_deterministic_beliefs():

--- a/timely_beliefs/tests/test_belief_utils.py
+++ b/timely_beliefs/tests/test_belief_utils.py
@@ -1,0 +1,32 @@
+import pandas as pd
+
+from timely_beliefs.examples import get_example_df
+from timely_beliefs.beliefs.probabilistic_utils import get_median_belief
+from timely_beliefs.beliefs.utils import propagate_beliefs
+
+
+def test_propagate_multi_sourced_deterministic_beliefs():
+    df = get_example_df().for_each_belief(get_median_belief)
+
+    # Set the four later beliefs to an unknown value
+    df[
+        df.index.get_level_values("belief_time")
+        == pd.Timestamp("2000-01-01 01:00:00+00:00")
+    ] = None
+    assert df["event_value"].isnull().sum() == 8
+
+    # Propagate the four earlier beliefs
+    df = propagate_beliefs(df)
+    assert df["event_value"].isnull().sum() == 0
+
+    # After propagating the four later beliefs should be equal to the four earlier beliefs
+    pd.testing.assert_frame_equal(
+        df[
+            df.index.get_level_values("belief_time")
+            == pd.Timestamp("2000-01-01 00:00:00+00:00")
+        ].droplevel("belief_time"),
+        df[
+            df.index.get_level_values("belief_time")
+            == pd.Timestamp("2000-01-01 01:00:00+00:00")
+        ].droplevel("belief_time"),
+    )

--- a/timely_beliefs/tests/test_belief_utils.py
+++ b/timely_beliefs/tests/test_belief_utils.py
@@ -20,7 +20,7 @@ def test_propagate_multi_sourced_deterministic_beliefs():
     df = propagate_beliefs(df)
     assert df["event_value"].isnull().sum() == 0
 
-    # After propagating the four later beliefs should be equal to the four earlier beliefs
+    # After propagating, the four later beliefs should be equal to the four earlier beliefs
     pd.testing.assert_frame_equal(
         df[
             df.index.get_level_values("belief_time")

--- a/timely_beliefs/tests/test_belief_utils.py
+++ b/timely_beliefs/tests/test_belief_utils.py
@@ -6,6 +6,7 @@ from timely_beliefs.beliefs.utils import propagate_beliefs
 
 
 def test_propagate_multi_sourced_deterministic_beliefs():
+    # Start with a deterministic example frame (4 events, 2 sources and 2 belief times)
     df = get_example_df().for_each_belief(get_median_belief)
 
     # Set the four later beliefs to an unknown value


### PR DESCRIPTION
I encountered the following use case, where I needed to do some computation on 3 sensors that had information about the same event start, but with 3 different belief times. At the first 2 belief times, not all information was known, but at the third belief time all information was known. It just wasn't propagated yet. This PR implements the required util function to propagate beliefs over time.

That is:
```
                                                                                      temp_air  \
event_start               belief_time               source    cumulative_probability             
2022-07-01 02:00:00+02:00 2022-06-30 15:10:30+02:00 simulator 0.5                          NaN   
                          2022-07-01 01:10:41+02:00 simulator 0.5                        13.61   
                          2022-07-01 02:10:32+02:00 simulator 0.5                          NaN   
                                                                                      wind_speed  \
event_start               belief_time               source    cumulative_probability               
2022-07-01 02:00:00+02:00 2022-06-30 15:10:30+02:00 simulator 0.5                            NaN   
                          2022-07-01 01:10:41+02:00 simulator 0.5                            NaN   
                          2022-07-01 02:10:32+02:00 simulator 0.5                           2.88   
                                                                                      cloud_cover  
event_start               belief_time               source    cumulative_probability               
2022-07-01 02:00:00+02:00 2022-06-30 15:10:30+02:00 simulator 0.5                            0.94  
                          2022-07-01 01:10:41+02:00 simulator 0.5                             NaN  
                          2022-07-01 02:10:32+02:00 simulator 0.5                             NaN  
```

Should become:
```
                                                                                      temp_air  \
event_start               belief_time               source    cumulative_probability             
2022-07-01 02:00:00+02:00 2022-06-30 15:10:30+02:00 simulator 0.5                          NaN   
                          2022-07-01 01:10:41+02:00 simulator 0.5                        13.61   
                          2022-07-01 02:10:32+02:00 simulator 0.5                        13.61   
                                                                                      wind_speed  \
event_start               belief_time               source    cumulative_probability               
2022-07-01 02:00:00+02:00 2022-06-30 15:10:30+02:00 simulator 0.5                            NaN   
                          2022-07-01 01:10:41+02:00 simulator 0.5                            NaN   
                          2022-07-01 02:10:32+02:00 simulator 0.5                           2.88   
                                                                                      cloud_cover  
event_start               belief_time               source    cumulative_probability               
2022-07-01 02:00:00+02:00 2022-06-30 15:10:30+02:00 simulator 0.5                            0.94  
                          2022-07-01 01:10:41+02:00 simulator 0.5                            0.94  
                          2022-07-01 02:10:32+02:00 simulator 0.5                            0.94  
```