### PR TITLE
Support pandas 1.4

### DIFF
--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -1386,12 +1386,10 @@ class BeliefsDataFrame(pd.DataFrame):
                     # back up NaN values
                     unique_event_value_not_in_df = df["event_value"].abs().sum() + 1
                     df = df.fillna(unique_event_value_not_in_df)
-                new_index = pd.date_range(
+                new_index = belief_utils.initialize_index(
                     start=df.index[0],
                     end=df.index[-1] + self.event_resolution,
-                    closed="left",
-                    freq=event_resolution,
-                    name="event_start",
+                    resolution=event_resolution,
                 )
                 # Reindex to introduce NaN values, then forward fill by the number of steps
                 # needed to have the new resolution cover the old resolution.

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -642,6 +642,11 @@ def interpret_special_read_cases(
 def initialize_index(
     start: datetime, end: datetime, resolution: timedelta, inclusive: str = "left"
 ) -> pd.DatetimeIndex:
+    """Initialize DatetimeIndex for event starts.
+
+    Supports updated function signature of pd.date_range.
+    From pandas>=1.4.0, it is clear that 'closed' will be replaced by 'inclusive'.
+    """
     if version.parse(pd.__version__) >= version.parse("1.4.0"):
         return pd.date_range(
             start=start,

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -134,12 +134,10 @@ def respect_event_resolution(grouper: DataFrameGroupBy, resolution):
         # Get the BeliefsDataFrame for a unique belief time and source
         df_slice = group[1]
         if not df_slice.empty:
-            lvl0 = pd.date_range(
+            lvl0 = initialize_index(
                 start=bin_start,
                 end=bin_end,
-                freq=resolution,
-                closed="left",
-                name="event_start",
+                resolution=resolution,
             )
             df = df.append(
                 tb_utils.replace_multi_index_level(

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -1,10 +1,10 @@
 import warnings
 from datetime import datetime, timedelta
-from packaging import version
 from typing import List, Optional, Union
 
 import numpy as np
 import pandas as pd
+from packaging import version
 from pandas.core.groupby import DataFrameGroupBy
 
 from timely_beliefs import BeliefSource, Sensor

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -1,5 +1,6 @@
 import warnings
 from datetime import datetime, timedelta
+from packaging import version
 from typing import List, Optional, Union
 
 import numpy as np
@@ -636,6 +637,23 @@ def interpret_special_read_cases(
             sensor.timezone
         )
     return df
+
+
+def initialize_index(
+    start: datetime, end: datetime, resolution: timedelta, inclusive: str = "left"
+) -> pd.DatetimeIndex:
+    if version.parse(pd.__version__) >= version.parse("1.4.0"):
+        return pd.date_range(
+            start=start,
+            end=end,
+            freq=resolution,
+            inclusive=inclusive,
+            name="event_start",
+        )
+    else:
+        return pd.date_range(
+            start=start, end=end, freq=resolution, closed=inclusive, name="event_start"
+        )
 
 
 def is_pandas_structure(x):


### PR DESCRIPTION
This PR gets rid of several `FutureWarning` log messages when running timely-beliefs with `pandas>=1.4`.