### PR TITLE
Fix for extreme timedelta bounds

### DIFF
--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -461,12 +461,12 @@ class TimedBeliefDBMixin(TimedBelief):
             q = q.filter(cls.event_start + sensor.event_resolution <= event_ends_before)
 
         # Apply rough belief time filter
-        if not pd.isnull(beliefs_after):
+        if not pd.isnull(beliefs_after) and knowledge_horizon_min != timedelta.min:
             q = q.filter(
                 cls.event_start
                 >= beliefs_after + cls.belief_horizon + knowledge_horizon_min
             )
-        if not pd.isnull(beliefs_before):
+        if not pd.isnull(beliefs_before) and knowledge_horizon_max != timedelta.max:
             q = q.filter(
                 cls.event_start
                 <= beliefs_before + cls.belief_horizon + knowledge_horizon_max

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -461,12 +461,16 @@ class TimedBeliefDBMixin(TimedBelief):
             q = q.filter(cls.event_start + sensor.event_resolution <= event_ends_before)
 
         # Apply rough belief time filter
-        if not pd.isnull(beliefs_after) and knowledge_horizon_min != timedelta.min:
+        if not pd.isnull(beliefs_after) and belief_utils.extreme_timedeltas_not_equal(
+            knowledge_horizon_min, timedelta.min
+        ):
             q = q.filter(
                 cls.event_start
                 >= beliefs_after + cls.belief_horizon + knowledge_horizon_min
             )
-        if not pd.isnull(beliefs_before) and knowledge_horizon_max != timedelta.max:
+        if not pd.isnull(beliefs_before) and belief_utils.extreme_timedeltas_not_equal(
+            knowledge_horizon_max, timedelta.max
+        ):
             q = q.filter(
                 cls.event_start
                 <= beliefs_before + cls.belief_horizon + knowledge_horizon_max

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -665,3 +665,15 @@ def is_pandas_structure(x):
 
 def is_tb_structure(x):
     return isinstance(x, (classes.BeliefsDataFrame, classes.BeliefsSeries))
+
+
+def extreme_timedeltas_not_equal(
+    td_a: Union[timedelta, pd.Timedelta],
+    td_b: timedelta,
+) -> bool:
+    """Workaround for pd.Timedelta(...) != timedelta.max (or min)
+    See pandas GH49021.
+    """
+    if isinstance(td_a, pd.Timedelta):
+        td_a = td_a.to_pytimedelta()
+    return td_a != td_b

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -25,7 +25,7 @@ def at_date(
     """
     if get_bounds:
         return timedelta.min, timedelta.max
-    return event_start - knowledge_time
+    return event_start - knowledge_time.astimezone(event_start.tzinfo)
 
 
 def ex_post(

--- a/timely_beliefs/sensors/utils.py
+++ b/timely_beliefs/sensors/utils.py
@@ -7,7 +7,7 @@ from isodate import (
     duration_isoformat,
     parse_datetime,
     parse_duration,
-    time_isoformat,
+    datetime_isoformat,
 )
 from pytz import timezone
 
@@ -43,7 +43,7 @@ def jsonify_time_dict(d: dict) -> dict:
     d2 = {}
     for k, v in d.items():
         if isinstance(v, datetime):
-            d2[k] = time_isoformat(v)
+            d2[k] = datetime_isoformat(v)
         elif isinstance(v, timedelta):
             d2[k] = duration_isoformat(v)
         else:

--- a/timely_beliefs/sensors/utils.py
+++ b/timely_beliefs/sensors/utils.py
@@ -4,10 +4,10 @@ from typing import Optional, Tuple, Union
 
 from isodate import (
     ISO8601Error,
+    datetime_isoformat,
     duration_isoformat,
     parse_datetime,
     parse_duration,
-    datetime_isoformat,
 )
 from pytz import timezone
 

--- a/timely_beliefs/tests/conftest.py
+++ b/timely_beliefs/tests/conftest.py
@@ -93,7 +93,7 @@ def unique_knowledge_time_sensor() -> DBSensor:
         knowledge_horizon=(
             at_date,
             dict(knowledge_time=datetime(1990, 5, 10, 0, tzinfo=utc)),
-        )
+        ),
     )
     session.add(sensor)
     session.flush()

--- a/timely_beliefs/tests/conftest.py
+++ b/timely_beliefs/tests/conftest.py
@@ -7,6 +7,7 @@ from pytz import utc
 from timely_beliefs import DBBeliefSource, DBSensor, DBTimedBelief
 from timely_beliefs.db_base import Base
 from timely_beliefs.sensors.func_store.knowledge_horizons import (
+    at_date,
     determine_ex_ante_knowledge_horizon_for_x_days_ago_at_y_oclock,
 )
 from timely_beliefs.tests import engine, session
@@ -77,6 +78,22 @@ def create_ex_post_time_slot_sensor(name: str) -> DBSensor:
             determine_ex_ante_knowledge_horizon_for_x_days_ago_at_y_oclock,
             dict(x=1, y=12, z="Europe/Amsterdam"),
         ),
+    )
+    session.add(sensor)
+    session.flush()
+    return sensor
+
+
+@pytest.fixture(scope="function", autouse=False)
+def unique_knowledge_time_sensor() -> DBSensor:
+    """Define sensor recording events with a unique knowledge time."""
+    sensor = DBSensor(
+        name="SinglePublicationSensor",
+        event_resolution=timedelta(hours=1),
+        knowledge_horizon=(
+            at_date,
+            dict(knowledge_time=datetime(1990, 5, 10, 0, tzinfo=utc)),
+        )
     )
     session.add(sensor)
     session.flush()

--- a/timely_beliefs/tests/test_belief_query.py
+++ b/timely_beliefs/tests/test_belief_query.py
@@ -46,6 +46,7 @@ def test_query_belief_for_sensor_with_unique_knowledge_time(
         belief_before=pd.Timestamp("1990-06-01 00:00Z"),
     ).convert_index_from_belief_time_to_horizon()
     assert belief_df.belief_horizons[0] == timedelta(0)
+    assert belief_df.knowledge_horizons[0] == timedelta(days=22)
 
 
 @pytest.fixture(scope="function")

--- a/timely_beliefs/tests/test_belief_query.py
+++ b/timely_beliefs/tests/test_belief_query.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
-from typing import List
 
 import numpy as np
 import pandas as pd
@@ -244,7 +245,7 @@ def test_query_belief_by_belief_time(
 
 def test_query_belief_history(
     ex_post_time_slot_sensor: DBSensor,
-    multiple_day_ahead_beliefs_about_ex_post_time_slot_event: List[DBTimedBelief],
+    multiple_day_ahead_beliefs_about_ex_post_time_slot_event: list[DBTimedBelief],
 ):
     df = DBTimedBelief.search_session(session=session, sensor=ex_post_time_slot_sensor)
     event_start = datetime(2025, 1, 2, 22, 45, tzinfo=utc)
@@ -357,7 +358,7 @@ def _test_empty_frame(time_slot_sensor):
 
 def test_search_by_sensor_id(
     ex_post_time_slot_sensor: DBSensor,
-    multiple_day_ahead_beliefs_about_ex_post_time_slot_event: List[DBTimedBelief],
+    multiple_day_ahead_beliefs_about_ex_post_time_slot_event: list[DBTimedBelief],
 ):
     """Check db query by sensor id, against query by sensor instance, for a non-empty dataset."""
 
@@ -376,8 +377,8 @@ def test_search_by_sensor_id(
 
 def test_select_most_recent_deterministic_beliefs(
     ex_post_time_slot_sensor: DBSensor,
-    multiple_day_ahead_beliefs_about_ex_post_time_slot_event: List[DBTimedBelief],
-    multiple_day_after_beliefs_about_ex_post_time_slot_event: List[DBTimedBelief],
+    multiple_day_ahead_beliefs_about_ex_post_time_slot_event: list[DBTimedBelief],
+    multiple_day_after_beliefs_about_ex_post_time_slot_event: list[DBTimedBelief],
 ):
     """Check db query filters for most recent beliefs, most recent events, and both at once."""
 
@@ -430,7 +431,7 @@ def test_select_most_recent_deterministic_beliefs(
 
 def test_select_most_recent_probabilistic_beliefs(
     ex_post_time_slot_sensor: DBSensor,
-    multiple_probabilistic_day_ahead_beliefs_about_ex_post_time_slot_event: List[
+    multiple_probabilistic_day_ahead_beliefs_about_ex_post_time_slot_event: list[
         DBTimedBelief
     ],
 ):


### PR DESCRIPTION
Fix for using the `at_date` knowledge horizon function, used for sensors with a unique knowledge time. I also opened a [Pandas issue](https://github.com/pandas-dev/pandas/issues/49021) for comparing a `pd.Timedelta` to `timedelta.max`.

Also added a test and fixed the iso formatting of datetimes in knowledge horizon parameters.