### PR TITLE
Read csv with keep_default_na

### DIFF
--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -569,6 +569,10 @@ def read_csv(
             f"Extension {ext} not recognized. Accepted file extensions are csv, xlsx and xls."
         )
 
+    # Exclude rows with NaN or NaT values
+    if "keep_default_na" in kwargs and kwargs.get("keep_default_na") is False:
+        df = df.dropna()
+
     # Preserve order of usecols
     if "usecols" in kwargs:
         df = df[kwargs["usecols"]]

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -570,7 +570,7 @@ def read_csv(
         )
 
     # Exclude rows with NaN or NaT values
-    if "keep_default_na" in kwargs and kwargs.get("keep_default_na") is False:
+    if not kwargs.get("keep_default_na", True):
         df = df.dropna()
 
     # Preserve order of usecols

--- a/timely_beliefs/tests/test_belief_io.py
+++ b/timely_beliefs/tests/test_belief_io.py
@@ -97,7 +97,7 @@ def test_load_beliefs_with_nat_values(csv_nat_file):
         sensor=tb.Sensor("Sensor Y"),
         source=tb.BeliefSource("Source A"),
         timezone="Europe/Amsterdam",
-        na_values=[""],
+        na_values=[""],  # tells pd.read_csv to treat empty cells as NaN values
         keep_default_na=False,
     )
     assert len(df) == len(get_example_df()) - 1


### PR DESCRIPTION
I was expecting this `pd.read_csv` option to filter out `np.NaT` values, too, but saw they still slipped through.