### PR TITLE
Print meta data

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ as we show here in a printout of the example BeliefsDataFrame in our examples mo
                               2000-01-01 01:00:00+00:00 Source A 0.1587                           99
                                                                  0.5000                          100
                                                                  0.8413                          101
-    sensor: <Sensor: Sensor 1>, event_resolution: datetime.timedelta(seconds=900)
+    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=900)
 
 The first 8 entries of this BeliefsDataFrame show beliefs about a single event.
 Beliefs were formed by two distinct sources (A and B), with the first updating its beliefs at a later time.
@@ -94,8 +94,8 @@ Source B thought the value would be equally likely to be 0 or 100.
 More information about what actually constitutes an event is stored as metadata in the BeliefsDataFrame, which is printed out just below the frame.
 The sensor property keeps track of invariable information such as the unit of the data and the resolution of events.
 
-    >>> df.sensor
-    <Sensor: Sensor 1>
+    >>> df.sensor.unit
+    'kg'
 
 Currently, a BeliefsDataFrame contains data about a single sensor only.
 _For a future release we are considering adding the sensor as another index level,
@@ -133,7 +133,7 @@ for example, some days before each event ends.
     source
     Source A    1.482075  0.014821  0.005928
     Source B  125.853250  0.503413  0.503413
-    sensor: <Sensor: Sensor 1>, event_resolution: datetime.timedelta(seconds=900)
+    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=900)
 
 With a fixed viewpoint, you get the accuracy of beliefs held at a certain `belief_time`.
 
@@ -144,7 +144,7 @@ With a fixed viewpoint, you get the accuracy of beliefs held at a certain `belie
     source
     Source A    0.00000  0.000000  0.000000
     Source B  125.85325  0.503413  0.503413
-    sensor: <Sensor: Sensor 1>, event_resolution: datetime.timedelta(seconds=900)
+    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=900)
 
 For an intuitive representation of accuracy that works in many cases, we suggest to use:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Getting started (or try one of the [other ways to create a BeliefsDataFrame](tim
                                                                                             event_value
     event_start               belief_time               source      cumulative_probability             
     2000-03-05 11:00:00+00:00 2000-03-05 11:00:00+00:00 Thermometer 0.5                              21
-    sensor: <Sensor: Indoor temperature>, event_resolution: datetime.timedelta(0)
+    sensor: <Sensor: Indoor temperature>, event_resolution: 0:00:00
 
 The package contains the following functionality:
 
@@ -83,7 +83,7 @@ as we show here in a printout of the example BeliefsDataFrame in our examples mo
                               2000-01-01 01:00:00+00:00 Source A 0.1587                           99
                                                                  0.5000                          100
                                                                  0.8413                          101
-    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=900)
+    sensor: <Sensor: weight>, event_resolution: 0:15:00
 
 The first 8 entries of this BeliefsDataFrame show beliefs about a single event.
 Beliefs were formed by two distinct sources (A and B), with the first updating its beliefs at a later time.
@@ -133,7 +133,7 @@ for example, some days before each event ends.
     source
     Source A    1.482075  0.014821  0.005928
     Source B  125.853250  0.503413  0.503413
-    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=900)
+    sensor: <Sensor: weight>, event_resolution: 0:15:00
 
 With a fixed viewpoint, you get the accuracy of beliefs held at a certain `belief_time`.
 
@@ -144,7 +144,7 @@ With a fixed viewpoint, you get the accuracy of beliefs held at a certain `belie
     source
     Source A    0.00000  0.000000  0.000000
     Source B  125.85325  0.503413  0.503413
-    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=900)
+    sensor: <Sensor: weight>, event_resolution: 0:15:00
 
 For an intuitive representation of accuracy that works in many cases, we suggest to use:
 

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -663,6 +663,16 @@ class BeliefsSeries(pd.Series):
         super().__init__(*args, **kwargs)
         return
 
+    def __repr__(self):
+        """Add the sensor and event resolution to the string representation of the BeliefsSeries."""
+        return (
+            super().__repr__()
+            + "\nsensor: "
+            + self.sensor.__repr__()
+            + ", event_resolution: "
+            + self.event_resolution.__repr__()
+        )
+
 
 class BeliefsDataFrame(pd.DataFrame):
     """Beliefs about a sensor.

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -43,7 +43,7 @@ from sqlalchemy.sql.expression import Selectable
 import timely_beliefs.utils as tb_utils
 from timely_beliefs.beliefs import probabilistic_utils
 from timely_beliefs.beliefs import utils as belief_utils
-from timely_beliefs.beliefs.utils import is_pandas_structure, is_tb_structure
+from timely_beliefs.beliefs.utils import is_pandas_structure, is_tb_structure, meta_repr
 from timely_beliefs.db_base import Base
 from timely_beliefs.sensors import utils as sensor_utils
 from timely_beliefs.sensors.classes import DBSensor, Sensor, SensorDBMixin
@@ -665,13 +665,7 @@ class BeliefsSeries(pd.Series):
 
     def __repr__(self):
         """Add the sensor and event resolution to the string representation of the BeliefsSeries."""
-        return (
-            super().__repr__()
-            + "\nsensor: "
-            + self.sensor.__repr__()
-            + ", event_resolution: "
-            + self.event_resolution.__repr__()
-        )
+        return super().__repr__() + "\n" + meta_repr(self)
 
 
 class BeliefsDataFrame(pd.DataFrame):
@@ -2048,13 +2042,7 @@ class BeliefsDataFrame(pd.DataFrame):
 
     def __repr__(self):
         """Add the sensor and event resolution to the string representation of the BeliefsDataFrame."""
-        return (
-            super().__repr__()
-            + "\nsensor: "
-            + self.sensor.__repr__()
-            + ", event_resolution: "
-            + self.event_resolution.__repr__()
-        )
+        return super().__repr__() + "\n" + meta_repr(self)
 
 
 def set_columns_and_indices_for_empty_frame(df, columns, indices, default_types):

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -2036,6 +2036,16 @@ class BeliefsDataFrame(pd.DataFrame):
             return df.convert_index_from_belief_horizon_to_time()
         return pd.concat([df, reference_df], axis=1)
 
+    def __repr__(self):
+        """Add the sensor and event resolution to the string representation of the BeliefsDataFrame."""
+        return (
+            super().__repr__()
+            + "\nsensor: "
+            + self.sensor.__repr__()
+            + ", event_resolution: "
+            + self.event_resolution.__repr__()
+        )
+
 
 def set_columns_and_indices_for_empty_frame(df, columns, indices, default_types):
     """Set appropriate columns and indices for the empty BeliefsDataFrame."""

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -776,3 +776,14 @@ def extreme_timedeltas_not_equal(
     if isinstance(td_a, pd.Timedelta):
         td_a = td_a.to_pytimedelta()
     return td_a != td_b
+
+
+def meta_repr(
+    tb_structure: Union["classes.BeliefsDataFrame", "classes.BeliefsSeries"]
+) -> str:
+    return (
+        "sensor: "
+        + tb_structure.sensor.__repr__()
+        + ", event_resolution: "
+        + tb_structure.event_resolution.__repr__()
+    )

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -787,7 +787,7 @@ def meta_repr(
     >>> from timely_beliefs.examples import get_example_df
     >>> df = get_example_df()
     >>> print(meta_repr(df))
-    sensor: <Sensor: Sensor 1>, event_resolution: datetime.timedelta(seconds=900)
+    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=900)
     """
     return ", ".join(
         [

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -787,11 +787,11 @@ def meta_repr(
     >>> from timely_beliefs.examples import get_example_df
     >>> df = get_example_df()
     >>> print(meta_repr(df))
-    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=900)
+    sensor: <Sensor: weight>, event_resolution: 0:15:00
     """
     return ", ".join(
         [
-            ": ".join([attr, getattr(tb_structure, attr).__repr__()])
+            ": ".join([attr, str(getattr(tb_structure, attr))])
             for attr in tb_structure._metadata
         ]
     )

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -781,9 +781,9 @@ def extreme_timedeltas_not_equal(
 def meta_repr(
     tb_structure: Union["classes.BeliefsDataFrame", "classes.BeliefsSeries"]
 ) -> str:
-    return (
-        "sensor: "
-        + tb_structure.sensor.__repr__()
-        + ", event_resolution: "
-        + tb_structure.event_resolution.__repr__()
+    return ", ".join(
+        [
+            ": ".join([attr, getattr(tb_structure, attr).__repr__()])
+            for attr in tb_structure._metadata
+        ]
     )

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -786,8 +786,8 @@ def meta_repr(
     For example:
     >>> from timely_beliefs.examples import get_example_df
     >>> df = get_example_df()
-    >>> print(meta_repr(df))
-    sensor: <Sensor: weight>, event_resolution: 0:15:00
+    >>> meta_repr(df)
+    'sensor: <Sensor: weight>, event_resolution: 0:15:00'
     """
     return ", ".join(
         [

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -781,6 +781,14 @@ def extreme_timedeltas_not_equal(
 def meta_repr(
     tb_structure: Union["classes.BeliefsDataFrame", "classes.BeliefsSeries"]
 ) -> str:
+    """Returns a string representation of all metadata.
+
+    For example:
+    >>> from timely_beliefs.examples import get_example_df
+    >>> df = get_example_df()
+    >>> print(meta_repr(df))
+    sensor: <Sensor: Sensor 1>, event_resolution: datetime.timedelta(seconds=900)
+    """
     return ", ".join(
         [
             ": ".join([attr, getattr(tb_structure, attr).__repr__()])

--- a/timely_beliefs/docs/init.md
+++ b/timely_beliefs/docs/init.md
@@ -42,7 +42,7 @@ Required arguments:
     event_start               belief_horizon source cumulative_probability             
     2000-01-03 09:00:00+00:00 0 days         EPEX   0.5                              63
     2000-01-04 09:00:00+00:00 0 days         EPEX   0.5                              60
-    sensor: <Sensor: EPEX SPOT day-ahead price>, event_resolution: datetime.timedelta(seconds=3600)
+    sensor: <Sensor: EPEX SPOT day-ahead price>, event_resolution: 1:00:00
 
 ## From a Pandas DataFrame
 
@@ -55,7 +55,7 @@ Pass a Pandas DataFrame with columns ["event_start", "belief_time", "source", "c
     event_start               belief_horizon source cumulative_probability             
     2000-01-03 09:00:00+00:00 0 days         EPEX   0.5                              63
     2000-01-03 10:00:00+00:00 0 days         EPEX   0.5                              60
-    sensor: <Sensor: EPEX SPOT day-ahead price>, event_resolution: datetime.timedelta(seconds=3600)
+    sensor: <Sensor: EPEX SPOT day-ahead price>, event_resolution: 1:00:00
 
 Alternatively, a keyword argument can be used to replace a column that contains the same value for each belief.
 
@@ -66,7 +66,7 @@ Alternatively, a keyword argument can be used to replace a column that contains 
     event_start               belief_horizon source cumulative_probability             
     2000-01-03 09:00:00+00:00 0 days         EPEX   0.5                              63
     2000-01-03 10:00:00+00:00 0 days         EPEX   0.5                              60
-    sensor: <Sensor: EPEX SPOT day-ahead price>, event_resolution: datetime.timedelta(seconds=3600)
+    sensor: <Sensor: EPEX SPOT day-ahead price>, event_resolution: 1:00:00
 
 ## From a CSV file
 
@@ -103,4 +103,4 @@ Create a list of `TimedBelief` or `DBTimedBelief` objects and use it to initiali
     event_start               belief_time               source cumulative_probability             
     2000-01-03 09:00:00+00:00 2000-01-03 10:00:00+00:00 EPEX   0.5                              63
     2000-01-03 10:00:00+00:00 2000-01-03 11:00:00+00:00 EPEX   0.5                              60
-    sensor: <Sensor: EPEX SPOT day-ahead price>, event_resolution: datetime.timedelta(seconds=3600)
+    sensor: <Sensor: EPEX SPOT day-ahead price>, event_resolution: 1:00:00

--- a/timely_beliefs/docs/init.md
+++ b/timely_beliefs/docs/init.md
@@ -34,6 +34,7 @@ Required arguments:
 
 
     >>> import pandas as pd
+    >>> import pytz
     >>> s = pd.Series([63, 60], index=pd.date_range(datetime(2000, 1, 3, 9), periods=2, tz=pytz.utc))
     >>> bdf = tb.BeliefsDataFrame(s, belief_horizon=timedelta(hours=0), source=source, sensor=sensor)
     >>> print(bdf)
@@ -41,6 +42,7 @@ Required arguments:
     event_start               belief_horizon source cumulative_probability             
     2000-01-03 09:00:00+00:00 0 days         EPEX   0.5                              63
     2000-01-04 09:00:00+00:00 0 days         EPEX   0.5                              60
+    sensor: <Sensor: EPEX SPOT day-ahead price>, event_resolution: datetime.timedelta(seconds=3600)
 
 ## From a Pandas DataFrame
 
@@ -53,6 +55,7 @@ Pass a Pandas DataFrame with columns ["event_start", "belief_time", "source", "c
     event_start               belief_horizon source cumulative_probability             
     2000-01-03 09:00:00+00:00 0 days         EPEX   0.5                              63
     2000-01-03 10:00:00+00:00 0 days         EPEX   0.5                              60
+    sensor: <Sensor: EPEX SPOT day-ahead price>, event_resolution: datetime.timedelta(seconds=3600)
 
 Alternatively, a keyword argument can be used to replace a column that contains the same value for each belief.
 
@@ -63,6 +66,7 @@ Alternatively, a keyword argument can be used to replace a column that contains 
     event_start               belief_horizon source cumulative_probability             
     2000-01-03 09:00:00+00:00 0 days         EPEX   0.5                              63
     2000-01-03 10:00:00+00:00 0 days         EPEX   0.5                              60
+    sensor: <Sensor: EPEX SPOT day-ahead price>, event_resolution: datetime.timedelta(seconds=3600)
 
 ## From a CSV file
 
@@ -99,3 +103,4 @@ Create a list of `TimedBelief` or `DBTimedBelief` objects and use it to initiali
     event_start               belief_time               source cumulative_probability             
     2000-01-03 09:00:00+00:00 2000-01-03 10:00:00+00:00 EPEX   0.5                              63
     2000-01-03 10:00:00+00:00 2000-01-03 11:00:00+00:00 EPEX   0.5                              60
+    sensor: <Sensor: EPEX SPOT day-ahead price>, event_resolution: datetime.timedelta(seconds=3600)

--- a/timely_beliefs/docs/resampling.md
+++ b/timely_beliefs/docs/resampling.md
@@ -29,7 +29,7 @@ Upsample to events with a resolution of 5 minutes:
     2000-01-03 09:10:00+00:00 2000-01-01 00:00:00+00:00 Source A 0.1587                         90.0
                                                                  0.5000                        100.0
                                                                  0.8413                        110.0
-    sensor: <Sensor: Sensor 1>, event_resolution: datetime.timedelta(seconds=300)
+    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=300)
 
 When resampling, the event resolution of the underlying sensor remains the same (it's still a fixed property of the sensor):
 
@@ -68,7 +68,7 @@ Downsample to events with a resolution of 2 hours:
     2000-01-03 12:00:00+00:00 2000-01-01 00:00:00+00:00 Source A 0.158700                      360.0
                                                                  0.500000                      400.0
                                                                  1.000000                      440.0
-    sensor: <Sensor: Sensor 1>, event_resolution: datetime.timedelta(seconds=7200)
+    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=7200)
     >>> -df2h.knowledge_horizons[0]
     Timedelta('0 days 02:00:00')
 

--- a/timely_beliefs/docs/resampling.md
+++ b/timely_beliefs/docs/resampling.md
@@ -29,7 +29,7 @@ Upsample to events with a resolution of 5 minutes:
     2000-01-03 09:10:00+00:00 2000-01-01 00:00:00+00:00 Source A 0.1587                         90.0
                                                                  0.5000                        100.0
                                                                  0.8413                        110.0
-    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=300)
+    sensor: <Sensor: weight>, event_resolution: 0:05:00
 
 When resampling, the event resolution of the underlying sensor remains the same (it's still a fixed property of the sensor):
 
@@ -68,7 +68,7 @@ Downsample to events with a resolution of 2 hours:
     2000-01-03 12:00:00+00:00 2000-01-01 00:00:00+00:00 Source A 0.158700                      360.0
                                                                  0.500000                      400.0
                                                                  1.000000                      440.0
-    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=7200)
+    sensor: <Sensor: weight>, event_resolution: 2:00:00
     >>> -df2h.knowledge_horizons[0]
     Timedelta('0 days 02:00:00')
 

--- a/timely_beliefs/docs/resampling.md
+++ b/timely_beliefs/docs/resampling.md
@@ -14,7 +14,8 @@ Resampling a BeliefsDataFrame can be an expensive operation, especially when the
 Upsample to events with a resolution of 5 minutes:
 
     >>> from datetime import timedelta
-    >>> df = timely_beliefs.examples.get_example_df()
+    >>> import timely_beliefs as tb
+    >>> df = tb.examples.get_example_df()
     >>> df5m = df.resample_events(timedelta(minutes=5))
     >>> df5m.sort_index(level=["belief_time", "source"]).head(9)
                                                                                          event_value
@@ -28,6 +29,7 @@ Upsample to events with a resolution of 5 minutes:
     2000-01-03 09:10:00+00:00 2000-01-01 00:00:00+00:00 Source A 0.1587                         90.0
                                                                  0.5000                        100.0
                                                                  0.8413                        110.0
+    sensor: <Sensor: Sensor 1>, event_resolution: datetime.timedelta(seconds=300)
 
 When resampling, the event resolution of the underlying sensor remains the same (it's still a fixed property of the sensor):
 
@@ -66,6 +68,7 @@ Downsample to events with a resolution of 2 hours:
     2000-01-03 12:00:00+00:00 2000-01-01 00:00:00+00:00 Source A 0.158700                      360.0
                                                                  0.500000                      400.0
                                                                  1.000000                      440.0
+    sensor: <Sensor: Sensor 1>, event_resolution: datetime.timedelta(seconds=7200)
     >>> -df2h.knowledge_horizons[0]
     Timedelta('0 days 02:00:00')
 

--- a/timely_beliefs/docs/slicing.md
+++ b/timely_beliefs/docs/slicing.md
@@ -39,7 +39,7 @@ Select the latest forecasts from a rolling viewpoint (beliefs formed at least 2 
                                                        1.0000                          300
     2000-01-03 12:00:00+00:00 2 days 11:15:00 Source A 0.1587                          396
                                                        0.5000                          400
-    sensor: <Sensor: Sensor 1>, event_resolution: datetime.timedelta(seconds=900)
+    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=900)
 
 ## Fixed viewpoint
 
@@ -56,7 +56,7 @@ Select the latest forecasts from a fixed viewpoint (beliefs formed at least befo
     2000-01-03 10:00:00+00:00 2000-01-01 01:00:00+00:00 Source A 0.1587                          198
                                                                  0.5000                          200
                                                                  0.8413                          202
-    sensor: <Sensor: Sensor 1>, event_resolution: datetime.timedelta(seconds=900)
+    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=900)
 
 ## Belief history
 
@@ -75,4 +75,4 @@ Select a history of beliefs about a single event:
                                        0.8413                          303
                               Source B 0.5000                            0
                                        1.0000                          300
-    sensor: <Sensor: Sensor 1>, event_resolution: datetime.timedelta(seconds=900)
+    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=900)

--- a/timely_beliefs/docs/slicing.md
+++ b/timely_beliefs/docs/slicing.md
@@ -13,9 +13,10 @@ Being an extension of the pandas DataFrame, all of pandas excellent slicing meth
 For example, to select all beliefs about events from 11 AM onwards:
 
     >>> from datetime import datetime, timedelta
-    >>> from pytz import utc
-    >>> df = timely_beliefs.examples.get_example_df()
-    >>> df[df.index.get_level_values("event_start") >= datetime(2000, 1, 3, 11, tzinfo=utc)]
+    >>> import pytz
+    >>> import timely_beliefs as tb
+    >>> df = tb.examples.get_example_df()
+    >>> df[df.index.get_level_values("event_start") >= datetime(2000, 1, 3, 11, tzinfo=pytz.utc)]
 
 Besides these, `timely-beliefs` provides custom methods to conveniently slice through time in different ways.
 
@@ -38,12 +39,13 @@ Select the latest forecasts from a rolling viewpoint (beliefs formed at least 2 
                                                        1.0000                          300
     2000-01-03 12:00:00+00:00 2 days 11:15:00 Source A 0.1587                          396
                                                        0.5000                          400
+    sensor: <Sensor: Sensor 1>, event_resolution: datetime.timedelta(seconds=900)
 
 ## Fixed viewpoint
 
 Select the latest forecasts from a fixed viewpoint (beliefs formed at least before 2 AM January 1st 2000:
 
-    >>> df.fixed_viewpoint(datetime(2000, 1, 1, 2, tzinfo=utc)).head(8)
+    >>> df.fixed_viewpoint(datetime(2000, 1, 1, 2, tzinfo=pytz.utc)).head(8)
                                                                                          event_value
     event_start               belief_time               source   cumulative_probability
     2000-01-03 09:00:00+00:00 2000-01-01 01:00:00+00:00 Source A 0.1587                           99
@@ -54,12 +56,13 @@ Select the latest forecasts from a fixed viewpoint (beliefs formed at least befo
     2000-01-03 10:00:00+00:00 2000-01-01 01:00:00+00:00 Source A 0.1587                          198
                                                                  0.5000                          200
                                                                  0.8413                          202
+    sensor: <Sensor: Sensor 1>, event_resolution: datetime.timedelta(seconds=900)
 
 ## Belief history
 
 Select a history of beliefs about a single event:
 
-    >>> df.belief_history(datetime(2000, 1, 3, 11, tzinfo=utc))
+    >>> df.belief_history(datetime(2000, 1, 3, 11, tzinfo=pytz.utc))
                                                                event_value
     belief_time               source   cumulative_probability
     2000-01-01 00:00:00+00:00 Source A 0.1587                          270
@@ -72,3 +75,4 @@ Select a history of beliefs about a single event:
                                        0.8413                          303
                               Source B 0.5000                            0
                                        1.0000                          300
+    sensor: <Sensor: Sensor 1>, event_resolution: datetime.timedelta(seconds=900)

--- a/timely_beliefs/docs/slicing.md
+++ b/timely_beliefs/docs/slicing.md
@@ -39,7 +39,7 @@ Select the latest forecasts from a rolling viewpoint (beliefs formed at least 2 
                                                        1.0000                          300
     2000-01-03 12:00:00+00:00 2 days 11:15:00 Source A 0.1587                          396
                                                        0.5000                          400
-    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=900)
+    sensor: <Sensor: weight>, event_resolution: 0:15:00
 
 ## Fixed viewpoint
 
@@ -56,7 +56,7 @@ Select the latest forecasts from a fixed viewpoint (beliefs formed at least befo
     2000-01-03 10:00:00+00:00 2000-01-01 01:00:00+00:00 Source A 0.1587                          198
                                                                  0.5000                          200
                                                                  0.8413                          202
-    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=900)
+    sensor: <Sensor: weight>, event_resolution: 0:15:00
 
 ## Belief history
 
@@ -75,4 +75,4 @@ Select a history of beliefs about a single event:
                                        0.8413                          303
                               Source B 0.5000                            0
                                        1.0000                          300
-    sensor: <Sensor: weight>, event_resolution: datetime.timedelta(seconds=900)
+    sensor: <Sensor: weight>, event_resolution: 0:15:00

--- a/timely_beliefs/examples/beliefs_data_frames.py
+++ b/timely_beliefs/examples/beliefs_data_frames.py
@@ -9,7 +9,7 @@ def sixteen_probabilistic_beliefs() -> BeliefsDataFrame:
     """Nice BeliefsDataFrame to show.
     For a single sensor, it contains 4 events, for each of which 2 beliefs by 2 sources each, described by 2 or 3
     probabilistic values, depending on the source.
-    Note that the event resolution of the sensor is 15 minutes.
+    Note that the event resolution of the sensor is 15 minutes, while the event start frequency is 1 hour.
     """
 
     n_events = 4
@@ -17,7 +17,9 @@ def sixteen_probabilistic_beliefs() -> BeliefsDataFrame:
     n_sources = 2
     true_value = 100
 
-    example_sensor = Sensor(event_resolution=timedelta(minutes=15), name="Sensor 1")
+    example_sensor = Sensor(
+        event_resolution=timedelta(minutes=15), name="weight", unit="kg"
+    )
     example_source_a = BeliefSource(name="Source A")
     example_source_b = BeliefSource(name="Source B")
 


### PR DESCRIPTION
This PR addresses a personal grievance. As a developer I'm often spending a little time finding out what sensor the data I'm looking at is about. From now on this information will be printed below the BeliefsDataFrame itself. This follows the Pandas convention for Series, which already prints out additional information such as:
```
Freq: H, Name: event_value, dtype: int64
```
In this PR, we start printing our custom metadata as well:
```
sensor: <Sensor: weight>, event_resolution: 0:15:00
```
If we add more metadata in the future (such as `unit`), that would then automatically show up as well.