### PR TITLE
Implement default resampling policy for upsampling when reading in beliefs data from CSV

### DIFF
--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -686,10 +686,13 @@ def interpret_special_read_cases(
         if resample:
             df = df.set_index("event_start")
             if df.index.freq is None and len(df) > 2:
+                # Try to infer the event resolution from the event frequency
                 df.index.freq = pd.infer_freq(df.index)
             if df.index.freq is not None and df.index.freq > sensor.event_resolution:
+                # Upsample by forward filling
                 df = df.resample(sensor.event_resolution).ffill()
             else:
+                # Downsample by computing the mean
                 df = df.resample(sensor.event_resolution).mean()
             df = df.reset_index()
     elif len(df.columns) == 3:

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -684,12 +684,14 @@ def interpret_special_read_cases(
             timezone_to_localize_to=timezone,
         )
         if resample:
-            df = (
-                df.set_index("event_start")
-                .resample(sensor.event_resolution)
-                .mean()
-                .reset_index()
-            )
+            df = df.set_index("event_start")
+            if df.index.freq is None and len(df) > 2:
+                df.index.freq = pd.infer_freq(df.index)
+            if df.index.freq is not None and df.index.freq > sensor.event_resolution:
+                df = df.resample(sensor.event_resolution).ffill()
+            else:
+                df = df.resample(sensor.event_resolution).mean()
+            df = df.reset_index()
     elif len(df.columns) == 3:
         # datetimes in 1st and 2nd column, and value in 3rd column
         df.columns = ["event_start", "belief_time", "event_value"]

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -701,7 +701,11 @@ def interpret_special_read_cases(
             if df.index.freq is None and len(df) > 2:
                 # Try to infer the event resolution from the event frequency
                 df.index.freq = pd.infer_freq(df.index)
-            if df.index.freq is not None and df.index.freq > sensor.event_resolution:
+            if df.index.freq is None:
+                raise NotImplementedError(
+                    "Resampling is not supported for data without a discernible frequency."
+                )
+            if df.index.freq > sensor.event_resolution:
                 # Upsample by forward filling
                 df = df.resample(sensor.event_resolution).ffill()
             else:


### PR DESCRIPTION
Sometimes you want to read in very low-res data from a CSV file and save it to a higher-res sensor (e.g. daily data saved to a hourly sensor). Not a very typical case, I would say, but I encountered it nonetheless. Usually, I believe it would point to a misconfigured sensor (too high-res), but it may also be intentional.