### PR TITLE
Resolve pandas future warnings

### DIFF
--- a/timely_beliefs/beliefs/__init__.py
+++ b/timely_beliefs/beliefs/__init__.py
@@ -141,7 +141,7 @@ class BeliefsAccessor(object):
     def unique_beliefs_per_event_per_source(self) -> bool:
         """Return whether or not the BeliefsDataFrame contains at most 1 belief per event per source."""
         return len(
-            self._obj.groupby(level=["event_start", "source", "cumulative_probability"])
+            self._obj.groupby(level=["event_start", "source", "cumulative_probability"], group_keys=False)
         ) == len(self._obj)
 
     @property

--- a/timely_beliefs/beliefs/__init__.py
+++ b/timely_beliefs/beliefs/__init__.py
@@ -141,7 +141,10 @@ class BeliefsAccessor(object):
     def unique_beliefs_per_event_per_source(self) -> bool:
         """Return whether or not the BeliefsDataFrame contains at most 1 belief per event per source."""
         return len(
-            self._obj.groupby(level=["event_start", "source", "cumulative_probability"], group_keys=False)
+            self._obj.groupby(
+                level=["event_start", "source", "cumulative_probability"],
+                group_keys=False,
+            )
         ) == len(self._obj)
 
     @property

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -1057,7 +1057,7 @@ class BeliefsDataFrame(pd.DataFrame):
         self, reference_source: BeliefSource
     ) -> "BeliefsDataFrame":
         return self.groupby(level=["event_start"], group_keys=False).apply(
-            lambda x: x.groupby(level=["source"]).pipe(
+            lambda x: x.groupby(level=["source"], group_keys=False).pipe(
                 probabilistic_utils.set_truth, reference_source
             )
         )
@@ -2108,7 +2108,7 @@ class BeliefsDataFrame(pd.DataFrame):
 
         df = self
 
-        reference_df = df.groupby(level="event_start").apply(
+        reference_df = df.groupby(level="event_start", group_keys=True).apply(
             lambda x: belief_utils.set_reference(
                 x,
                 reference_belief_time=reference_belief_time,

--- a/timely_beliefs/beliefs/probabilistic_utils.py
+++ b/timely_beliefs/beliefs/probabilistic_utils.py
@@ -92,7 +92,7 @@ def probabilistic_nan_mean(
         )
 
     # Extract the probabilistic values that will serve as marginal distributions
-    event_starts = df.groupby(["event_start"]).groups.keys()
+    event_starts = df.groupby(["event_start"], group_keys=False).groups.keys()
     cdf_v = []
     cdf_p = []
     for event_start in event_starts:

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -109,7 +109,7 @@ def respect_event_resolution(grouper: DataFrameGroupBy, resolution):
 
     :Example:
 
-    >>> df = df.groupby([pd.Grouper(freq="1D", level="event_start"), "belief_time", "source"]).pipe(respect_event_resolution, timedelta(hours=1))
+    >>> df = df.groupby([pd.Grouper(freq="1D", level="event_start"), "belief_time", "source"], group_keys=False).pipe(respect_event_resolution, timedelta(hours=1))
 
     So don't pass a BeliefsDataFrame directly, but pipe it so that we receive a DataFrameGroupBy object, which we can
     iterate over to obtain a BeliefsDataFrame slice for a unique belief time, source and (in our example) day of
@@ -185,7 +185,7 @@ def propagate_beliefs(
         raise NotImplementedError(
             "Propagating probabilistic beliefs is not yet implemented. Please file a GitHub issue."
         )
-    return df.groupby(level=["event_start", "source"]).ffill()
+    return df.groupby(level=["event_start", "source"], group_keys=False).ffill()
 
 
 def align_belief_times(

--- a/timely_beliefs/tests/test_belief_io.py
+++ b/timely_beliefs/tests/test_belief_io.py
@@ -537,7 +537,9 @@ def test_groupby_retains_metadata():
         assert_metadata_is_retained(x, original_df=example_df)
         return x
 
-    df = df.groupby(level="event_start", group_keys=False).apply(lambda x: assert_function(x))
+    df = df.groupby(level="event_start", group_keys=False).apply(
+        lambda x: assert_function(x)
+    )
     assert_metadata_is_retained(df, original_df=example_df)
 
 

--- a/timely_beliefs/tests/test_belief_io.py
+++ b/timely_beliefs/tests/test_belief_io.py
@@ -537,7 +537,7 @@ def test_groupby_retains_metadata():
         assert_metadata_is_retained(x, original_df=example_df)
         return x
 
-    df = df.groupby(level="event_start").apply(lambda x: assert_function(x))
+    df = df.groupby(level="event_start", group_keys=False).apply(lambda x: assert_function(x))
     assert_metadata_is_retained(df, original_df=example_df)
 
 
@@ -591,9 +591,9 @@ def test_groupby_does_not_retain_temporary_attribute():
     df = pd.DataFrame([[1, 2], [3, 4]], columns=["x", "y"])
     df.a = "b"
     assert df.a == "b"
-    df2 = df.groupby("x").apply(lambda x: x)
+    df2 = df.groupby("x", group_keys=False).apply(lambda x: x)
     assert not hasattr(df2, "a")
-    df3 = df.groupby("x").sum()
+    df3 = df.groupby("x", group_keys=False).sum()
     assert not hasattr(df3, "a")
 
 
@@ -665,7 +665,7 @@ def test_groupby_retains_subclass_attribute(att, args):
     df = SubclassedDataFrame([[1, 2], [3, 4]], columns=["x", "y"])
     df.a = "b"
     assert df.a == "b"
-    df2 = getattr(df.groupby("x"), att)(*args)
+    df2 = getattr(df.groupby("x", group_keys=False), att)(*args)
     print(df2)
     assert df2.a == "b"
 

--- a/timely_beliefs/tests/test_df_resampling.py
+++ b/timely_beliefs/tests/test_df_resampling.py
@@ -197,7 +197,7 @@ def test_upsample_probabilistic(df_4323, test_source_a: BeliefSource):
     assert (
         df.index.get_level_values(level="event_start").nunique() == 3 * 4
     )  # We have 3 events per quarterhour now
-    assert df.xs(datetime(2000, 1, 1), level="belief_time").xs(
+    assert df.xs(datetime(2000, 1, 1, tzinfo=pytz.utc), level="belief_time").xs(
         test_source_a, level="source"
     )["event_value"].values.tolist()[0:9] == [0, 1, 2, 0, 1, 2, 0, 1, 2]
 
@@ -210,8 +210,8 @@ def test_downsample_probabilistic(df_4323, test_source_a: BeliefSource):
     # Half of the events are binned together, with two 3-valued probabilistic beliefs turned into one 5-valued belief
     assert len(df) == 72 / 2 + 72 / 2 * 5 / 6
     cdf = (
-        df.xs(datetime(2000, 1, 3, 10), level="event_start")
-        .xs(datetime(2000, 1, 1), level="belief_time")
+        df.xs(datetime(2000, 1, 3, 10, tzinfo=pytz.utc), level="event_start")
+        .xs(datetime(2000, 1, 1, tzinfo=pytz.utc), level="belief_time")
         .xs(test_source_a, level="source")
     )
     cdf_p = cdf.index.get_level_values(level="cumulative_probability")

--- a/timely_beliefs/visualization/utils.py
+++ b/timely_beliefs/visualization/utils.py
@@ -254,7 +254,7 @@ def prepare_df_for_plotting(
     event_resolution = df.event_resolution
     df = df.convert_index_from_belief_horizon_to_time()
     if show_accuracy is True:
-        reference_df = df.groupby(level="event_start", group_keys=False).apply(
+        reference_df = df.groupby(level="event_start", group_keys=True).apply(
             lambda x: x.accuracy(reference_source=reference_source, lite_metrics=True)
         )
     else:

--- a/timely_beliefs/visualization/utils.py
+++ b/timely_beliefs/visualization/utils.py
@@ -254,7 +254,7 @@ def prepare_df_for_plotting(
     event_resolution = df.event_resolution
     df = df.convert_index_from_belief_horizon_to_time()
     if show_accuracy is True:
-        reference_df = df.groupby(level="event_start").apply(
+        reference_df = df.groupby(level="event_start", group_keys=False).apply(
             lambda x: x.accuracy(reference_source=reference_source, lite_metrics=True)
         )
     else:


### PR DESCRIPTION
Pandas==1.5 asks to be explicit about the `group_keys` argument and about the timezone when slicing a timezone-aware `DatetimeIndex` with another datetime.