### PR TITLE
Support Pandas 2

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Check (on Python3.9)
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9
-      - uses: actions/checkout@v2
-      - uses: pre-commit/action@v2.0.0
+      - uses: actions/checkout@v3
+      - uses: pre-commit/action@v3.0.0
 
   test:
     needs: check
@@ -26,10 +26,10 @@ jobs:
             skip-viz: true
     name: "Test (on Python ${{ matrix.py_version }})"
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.py_version }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run main tests
         run: make test
       - name: Run forecast tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
       - repo: https://github.com/PyCQA/isort
-        rev: 5.11.4  # New version tags can be found here: https://github.com/PyCQA/isort/tags
+        rev: 5.12.0  # New version tags can be found here: https://github.com/PyCQA/isort/tags
         hooks:
               - id: isort
                 name: isort (import sorting)
@@ -12,7 +12,7 @@ repos:
                 name: flake8 (code linting)
                 language_version: python3.9
       - repo: https://github.com/psf/black
-        rev: 22.12.0  # New version tags can be found here: https://github.com/psf/black/tags
+        rev: 23.3.0  # New version tags can be found here: https://github.com/psf/black/tags
         hooks:
               - id: black
                 name: black (code formatting)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
                 name: flake8 (code linting)
                 language_version: python3.9
       - repo: https://github.com/psf/black
-        rev: 23.3.0  # New version tags can be found here: https://github.com/psf/black/tags
+        rev: 22.12.0  # New version tags can be found here: https://github.com/psf/black/tags
         hooks:
               - id: black
                 name: black (code formatting)

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -1,7 +1,6 @@
 import math
 import types
 from datetime import datetime, timedelta
-from packaging import version
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -1,6 +1,7 @@
 import math
 import types
 from datetime import datetime, timedelta
+from packaging import version
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -662,8 +663,12 @@ class BeliefsSeries(pd.Series):
     @property
     def _constructor(self):
         def f(*args, **kwargs):
-            """Call __finalize__() after construction to inherit metadata."""
-            return BeliefsSeries(*args, **kwargs).__finalize__(self, method="inherit")
+            """Pre-Pandas 2.0, call __finalize__() after construction to inherit metadata."""
+            if version.parse(pd.__version__) < version.parse("2.0.0"):
+                return BeliefsSeries(*args, **kwargs).__finalize__(
+                    self, method="inherit"
+                )
+            return BeliefsSeries(*args, **kwargs)
 
         return f
 
@@ -739,10 +744,12 @@ class BeliefsDataFrame(pd.DataFrame):
     @property
     def _constructor(self):
         def f(*args, **kwargs):
-            """Call __finalize__() after construction to inherit metadata."""
-            return BeliefsDataFrame(*args, **kwargs).__finalize__(
-                self, method="inherit"
-            )
+            """Pre-Pandas 2.0, call __finalize__() after construction to inherit metadata."""
+            if version.parse(pd.__version__) < version.parse("2.0.0"):
+                return BeliefsDataFrame(*args, **kwargs).__finalize__(
+                    self, method="inherit"
+                )
+            return BeliefsDataFrame(*args, **kwargs)
 
         return f
 

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -745,12 +745,10 @@ class BeliefsDataFrame(pd.DataFrame):
     @property
     def _constructor(self):
         def f(*args, **kwargs):
-            """Pre-Pandas 2.0, call __finalize__() after construction to inherit metadata."""
-            if version.parse(pd.__version__) < version.parse("2.0.0"):
-                return BeliefsDataFrame(*args, **kwargs).__finalize__(
-                    self, method="inherit"
-                )
-            return BeliefsDataFrame(*args, **kwargs)
+            """Call __finalize__() after construction to inherit metadata."""
+            return BeliefsDataFrame(*args, **kwargs).__finalize__(
+                self, method="inherit"
+            )
 
         return f
 

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -1,6 +1,7 @@
 import math
 import types
 from datetime import datetime, timedelta
+from packaging import version
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -686,7 +687,7 @@ class BeliefsSeries(pd.Series):
         for name in self._metadata:
             object.__setattr__(self, name, getattr(other, name, None))
         if hasattr(other, "name"):
-            self.name = other.name
+            object.__setattr__(self, "name", getattr(other, "name"))
         return self
 
     def __init__(self, *args, **kwargs):

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -1,7 +1,6 @@
 import math
 import types
 from datetime import datetime, timedelta
-from packaging import version
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -13,6 +12,8 @@ from typing import (
     Type,
     Union,
 )
+
+from packaging import version
 
 if TYPE_CHECKING:
     import altair as alt

--- a/timely_beliefs/tests/test_belief_io.py
+++ b/timely_beliefs/tests/test_belief_io.py
@@ -549,7 +549,7 @@ def test_groupby_retains_metadata(test_df):
         assert_metadata_is_retained(x, original_df=original_df)
         return x
 
-    df = df.groupby(level="event_start", group_keys=False, dropna=False).apply(
+    df = df.groupby(level="event_start", group_keys=False).apply(
         lambda x: assert_function(x)
     )
     assert_metadata_is_retained(df, original_df=original_df)

--- a/timely_beliefs/tests/test_belief_io.py
+++ b/timely_beliefs/tests/test_belief_io.py
@@ -521,26 +521,39 @@ def _test_agg_resampling_retains_metadata(resolution):
     )  # todo: the event_resolution metadata is only updated when resampling using df.resample_events(). A reason to override the original resample method, or otherwise something to document.
 
 
-def test_groupby_retains_metadata():
+@pytest.mark.parametrize(
+    "test_df",
+    [
+        "example_df",
+        "empty_df",
+    ],
+)
+def test_groupby_retains_metadata(test_df):
     """Test whether grouping by index level retains the metadata.
 
     Succeeds with pandas==1.0.0
     Fails with pandas==1.1.0
     Fixed with pandas==1.1.5
     Fails with pandas==1.3.0
+    Fails with pandas==2.0.0
     """
-    example_df = get_example_df()
-    df = example_df
+    if test_df == "example_df":
+        original_df = get_example_df()
+    elif test_df == "empty_df":
+        original_df = tb.BeliefsDataFrame(sensor=tb.Sensor(name="test", unit="W"))
+    else:
+        raise NotImplementedError
+    df = original_df.copy()
 
     def assert_function(x):
         print(x)
-        assert_metadata_is_retained(x, original_df=example_df)
+        assert_metadata_is_retained(x, original_df=original_df)
         return x
 
-    df = df.groupby(level="event_start", group_keys=False).apply(
+    df = df.groupby(level="event_start", group_keys=False, dropna=False).apply(
         lambda x: assert_function(x)
     )
-    assert_metadata_is_retained(df, original_df=example_df)
+    assert_metadata_is_retained(df, original_df=original_df)
 
 
 def test_copy_series_retains_name_and_metadata():

--- a/timely_beliefs/tests/test_belief_io.py
+++ b/timely_beliefs/tests/test_belief_io.py
@@ -535,7 +535,6 @@ def test_groupby_retains_metadata(test_df):
     Fails with pandas==1.1.0
     Fixed with pandas==1.1.5
     Fails with pandas==1.3.0
-    Fails with pandas==2.0.0
     """
     if test_df == "example_df":
         original_df = get_example_df()

--- a/timely_beliefs/tests/test_belief_utils.py
+++ b/timely_beliefs/tests/test_belief_utils.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from timely_beliefs import BeliefsDataFrame, Sensor
 from timely_beliefs.beliefs.probabilistic_utils import get_median_belief
 from timely_beliefs.beliefs.utils import (
     propagate_beliefs,
@@ -9,6 +10,16 @@ from timely_beliefs.beliefs.utils import (
 )
 from timely_beliefs.examples import get_example_df
 from timely_beliefs.tests.utils import equal_lists
+
+
+def test_propagate_metadata_on_empty_frame():
+    df = BeliefsDataFrame(sensor=Sensor("test", unit="kW"))
+    df = df.for_each_belief(get_median_belief)
+    assert df.sensor.name == "test"
+    assert df.sensor.unit == "kW"
+    df = df.groupby(level=["event_start"], group_keys=False).apply(lambda x: x.head(1))
+    assert df.sensor.name == "test"
+    assert df.sensor.unit == "kW"
 
 
 def test_propagate_multi_sourced_deterministic_beliefs():

--- a/timely_beliefs/tests/test_belief_utils.py
+++ b/timely_beliefs/tests/test_belief_utils.py
@@ -13,6 +13,7 @@ from timely_beliefs.tests.utils import equal_lists
 
 
 def test_propagate_metadata_on_empty_frame():
+    """Check that calling these functions, which use groupby().apply(), on an empty frame retains the frame's metadata."""
     df = BeliefsDataFrame(sensor=Sensor("test", unit="kW"))
     df = df.for_each_belief(get_median_belief)
     assert df.sensor.name == "test"

--- a/timely_beliefs/tests/test_ignore_36__belief_init.py
+++ b/timely_beliefs/tests/test_ignore_36__belief_init.py
@@ -9,6 +9,7 @@ from timely_beliefs import utils
         ("1M", ValueError, "not parse"),
         ("1Y", ValueError, "not parse"),
         ("1y", ValueError, "not parse"),
+        ("y", ValueError, "not parse"),
     ],
 )
 def test_ambiguous_timedelta_parsing(td, ErrorType, match):

--- a/timely_beliefs/utils.py
+++ b/timely_beliefs/utils.py
@@ -30,6 +30,9 @@ def parse_timedelta_like(
                     # catch cases like "H" -> "1H"
                     if "unit abbreviation w/o a number" in str(e):
                         td = pd.Timedelta(f"1{td}")
+                    else:
+                        # Reraise needed since pandas==2.0.0 throws a ValueError for ambiguous timedelta, rather than a FutureWarning
+                        raise e
             if isinstance(td, pd.Timedelta):
                 td = td.to_pytimedelta()
     except (ValueError, FutureWarning) as e:


### PR DESCRIPTION
This should get us ready for upgrading to Pandas 2.

The good people of `sktime` are still working on compatibility with Pandas 2. Their latest release (0.17.1) already resolves any problems caught by our tests, but their `pyproject.toml` still suggests `pandas<2.0.0`.