### PR TITLE
feature: vectorize knowledge horizon function calls, and add some todos

### DIFF
--- a/timely_beliefs/beliefs/__init__.py
+++ b/timely_beliefs/beliefs/__init__.py
@@ -103,7 +103,7 @@ class BeliefsAccessor(object):
     def number_of_beliefs(self) -> int:
         """Return the total number of beliefs in the BeliefsDataFrame, including both deterministic beliefs (which
         require a single row) and probabilistic beliefs (which require multiple rows)."""
-        return len(self._obj.for_each_belief())
+        return len(self._obj.droplevel("cumulative_probability").index.unique())
 
     @property
     def sources(self) -> List[int]:

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -1079,23 +1079,11 @@ class BeliefsDataFrame(pd.DataFrame):
 
     @property
     def knowledge_times(self) -> pd.DatetimeIndex:
-        return pd.DatetimeIndex(
-            self.event_starts.to_series(name="knowledge_time").apply(
-                lambda event_start: self.sensor.knowledge_time(
-                    event_start, self.event_resolution
-                )
-            )
-        )
+        return self.sensor.knowledge_time(self.event_starts, self.event_resolution)
 
     @property
     def knowledge_horizons(self) -> pd.TimedeltaIndex:
-        return pd.TimedeltaIndex(
-            self.event_starts.to_series(name="knowledge_horizon").apply(
-                lambda event_start: self.sensor.knowledge_horizon(
-                    event_start, self.event_resolution
-                )
-            )
-        )
+        return self.sensor.knowledge_horizon(self.event_starts, self.event_resolution)
 
     @property
     def belief_times(self) -> pd.DatetimeIndex:

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -1219,8 +1219,10 @@ class BeliefsDataFrame(pd.DataFrame):
         return self._for_each_belief(fnc, True, *args, **kwargs)
 
     @hybrid_method
-    def make_deterministic(self):
-        return self.for_each_belief(probabilistic_utils.get_expected_belief)
+    def make_deterministic(self) -> "BeliefsDataFrame":
+        if self.lineage.probabilistic_depth > 1:
+            return self.for_each_belief(probabilistic_utils.get_expected_belief)
+        return self
 
     @hybrid_method
     def belief_history(

--- a/timely_beliefs/sensors/classes.py
+++ b/timely_beliefs/sensors/classes.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from typing import Any, Callable, Optional, Tuple, Union
 
+import pandas as pd
 from sqlalchemy import JSON, Column, Integer, Interval, String
 from sqlalchemy.ext.hybrid import hybrid_method
 
@@ -67,8 +70,10 @@ class Sensor(object):
 
     @hybrid_method
     def knowledge_horizon(
-        self, event_start: datetime, event_resolution: Optional[timedelta] = None
-    ) -> timedelta:
+        self,
+        event_start: datetime | pd.DatetimeIndex,
+        event_resolution: Optional[timedelta] = None,
+    ) -> timedelta | pd.TimedeltaIndex:
         event_start = enforce_tz(event_start, "event_start")
         if event_resolution is None:
             event_resolution = self.event_resolution
@@ -81,8 +86,10 @@ class Sensor(object):
 
     @hybrid_method
     def knowledge_time(
-        self, event_start: datetime, event_resolution: Optional[timedelta] = None
-    ) -> datetime:
+        self,
+        event_start: datetime | pd.DatetimeIndex,
+        event_resolution: Optional[timedelta] = None,
+    ) -> datetime | pd.DatetimeIndex:
         event_start = enforce_tz(event_start, "event_start")
         if event_resolution is None:
             event_resolution = self.event_resolution

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -12,10 +12,10 @@ from timely_beliefs.sensors.func_store.utils import datetime_x_days_ago_at_y_ocl
 
 
 def at_date(
-    event_start: datetime | pd.TimedeltaIndex | None,
+    event_start: datetime | pd.DatetimeIndex | None,
     knowledge_time: datetime,
     get_bounds: bool = False,
-) -> Union[timedelta, Tuple[timedelta, timedelta]]:
+) -> Union[timedelta | pd.TimedeltaIndex, Tuple[timedelta, timedelta]]:
     """Compute the sensor's knowledge horizon to represent the event could be known since some fixed date
     (knowledge time).
 
@@ -72,12 +72,12 @@ def ex_ante(
 
 
 def x_days_ago_at_y_oclock(
-    event_start: datetime | pd.TimedeltaIndex | None,
+    event_start: datetime | pd.DatetimeIndex | None,
     x: int,
     y: Union[int, float],
     z: str,
     get_bounds: bool = False,
-) -> Union[timedelta, Tuple[timedelta, timedelta]]:
+) -> Union[timedelta | pd.TimedeltaIndex, Tuple[timedelta, timedelta]]:
     """Compute the sensor's knowledge horizon to represent the event can be known some previous day at some hour.
 
     :param event_start: start of the event, used as an anchor for determining the knowledge time.

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -1,14 +1,18 @@
 """Function store for computing knowledge horizons given a certain event start and resolution.
 When passed get_bounds=True, these functions return bounds on the knowledge horizon,
 i.e. a duration window in which the knowledge horizon must lie (e.g. between 0 and 2 days before the event start)."""
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from typing import Optional, Tuple, Union
+
+import pandas as pd
 
 from timely_beliefs.sensors.func_store.utils import datetime_x_days_ago_at_y_oclock
 
 
 def at_date(
-    event_start: Optional[datetime],
+    event_start: datetime | pd.TimedeltaIndex | None,
     knowledge_time: datetime,
     get_bounds: bool = False,
 ) -> Union[timedelta, Tuple[timedelta, timedelta]]:
@@ -68,7 +72,7 @@ def ex_ante(
 
 
 def x_days_ago_at_y_oclock(
-    event_start: Optional[datetime],
+    event_start: datetime | pd.TimedeltaIndex | None,
     x: int,
     y: Union[int, float],
     z: str,

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -4,7 +4,7 @@ i.e. a duration window in which the knowledge horizon must lie (e.g. between 0 a
 from datetime import datetime, timedelta
 from typing import Optional, Tuple, Union
 
-from timely_beliefs.sensors.utils import datetime_x_days_ago_at_y_oclock
+from timely_beliefs.sensors.func_store.utils import datetime_x_days_ago_at_y_oclock
 
 
 def at_date(

--- a/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
@@ -30,6 +30,7 @@ def test_ex_post_knowledge_horizon():
 
 
 def test_fixed_knowledge_time():
+    """Check definition of knowledge horizon for events known at a fixed date."""
     knowledge_time = datetime(2020, 11, 20, 0, tzinfo=utc)
     assert determine_knowledge_horizon_for_fixed_knowledge_time(
         event_start=datetime(2020, 11, 19, 0, tzinfo=utc),
@@ -56,6 +57,8 @@ def test_fixed_knowledge_time():
 
 
 def test_dst():
+    """Check definition of knowledge horizon for events known x days ago at y o'clock in some timezone z,
+    especially around daylight savings time (DST) transitions."""
     tz_str = "Europe/Amsterdam"
 
     # Before daylight saving time starts
@@ -139,6 +142,8 @@ def test_dst():
 
 
 def test_dst_bounds():
+    """Check definition of bounds on the knowledge horizon for events known x days ago at y o'clock in some timezone z,
+    especially around daylight savings time (DST) transitions."""
     tz_str = "Europe/London"
 
     # Test bounds for Europe/London for double daylight saving time with respect to standard time

--- a/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
@@ -8,8 +8,25 @@ from timely_beliefs.sensors.func_store.knowledge_horizons import (
     at_date,
     determine_ex_ante_knowledge_horizon_for_x_days_ago_at_y_oclock,
     determine_knowledge_horizon_for_fixed_knowledge_time,
+    ex_ante,
+    ex_post,
     x_days_ago_at_y_oclock,
 )
+
+
+def test_ex_ante_knowledge_horizon():
+    """Check definition of knowledge horizon for ex-ante knowledge."""
+    assert ex_ante(
+        ex_ante_horizon=timedelta(minutes=15),
+    ) == timedelta(minutes=15), "The event should be known 15 minutes before it starts."
+
+
+def test_ex_post_knowledge_horizon():
+    """Check definition of knowledge horizon for ex-post knowledge."""
+    assert ex_post(
+        event_resolution=timedelta(minutes=15),
+        ex_post_horizon=timedelta(minutes=-5),
+    ) == timedelta(minutes=-10), "The event should be known 10 minutes after it starts."
 
 
 def test_fixed_knowledge_time():

--- a/timely_beliefs/sensors/func_store/utils.py
+++ b/timely_beliefs/sensors/func_store/utils.py
@@ -11,7 +11,7 @@ def datetime_x_days_ago_at_y_oclock(
     x: int,
     y: int | float,
     z: str,
-) -> datetime:
+) -> datetime | pd.DatetimeIndex:
     """Returns the datetime x days ago a y o'clock as determined from the perspective of timezone z."""
     if isinstance(y, float):
         micros = int(y * 60 * 60 * 10**6)

--- a/timely_beliefs/sensors/func_store/utils.py
+++ b/timely_beliefs/sensors/func_store/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import pandas as pd
 from pytz import timezone

--- a/timely_beliefs/sensors/func_store/utils.py
+++ b/timely_beliefs/sensors/func_store/utils.py
@@ -29,10 +29,9 @@ def datetime_x_days_ago_at_y_oclock(
         tz_naive_original_time = tz_aware_original_time.astimezone(tz).replace(
             tzinfo=None
         )
-        # todo: looks like a potential bug for dst transitions: we should first subtract the day, then set the time (better yet, subtract a calendar day using Pandas)
-        tz_naive_earlier_time = tz_naive_original_time.replace(
+        tz_naive_earlier_time = (tz_naive_original_time - pd.Timedelta(days=x)).replace(
             hour=h, minute=m, second=s, microsecond=micros
-        ) - timedelta(days=x)
+        )
         tz_aware_earlier_time = tz.localize(tz_naive_earlier_time).astimezone(
             original_tz
         )

--- a/timely_beliefs/sensors/func_store/utils.py
+++ b/timely_beliefs/sensors/func_store/utils.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from typing import Union
+
 from pytz import timezone
 
 

--- a/timely_beliefs/sensors/func_store/utils.py
+++ b/timely_beliefs/sensors/func_store/utils.py
@@ -36,10 +36,12 @@ def datetime_x_days_ago_at_y_oclock(
             original_tz
         )
     else:
-        tz_naive_original_time = tz_aware_original_time.tz_convert(tz)
+        tz_naive_original_time = tz_aware_original_time.tz_convert(tz).tz_localize(None)
         tz_naive_earlier_time = (tz_naive_original_time - pd.Timedelta(days=x)).floor(
             "D"
         ) + pd.Timedelta(hours=h, minutes=m, seconds=s, microseconds=micros)
-        tz_aware_earlier_time = tz_naive_earlier_time.tz_convert(original_tz)
+        tz_aware_earlier_time = tz_naive_earlier_time.tz_localize(tz).tz_convert(
+            original_tz
+        )
 
     return tz_aware_earlier_time

--- a/timely_beliefs/sensors/func_store/utils.py
+++ b/timely_beliefs/sensors/func_store/utils.py
@@ -1,0 +1,27 @@
+from datetime import datetime, timedelta
+from typing import Union
+from pytz import timezone
+
+
+def datetime_x_days_ago_at_y_oclock(
+    tz_aware_original_time: datetime, x: int, y: Union[int, float], z: str
+) -> datetime:
+    """Returns the datetime x days ago a y o'clock as determined from the perspective of timezone z."""
+    if isinstance(y, float):
+        micros = int(y * 60 * 60 * 10**6)
+        s, micros = divmod(micros, 10**6)
+        m, s = divmod(s, 60)
+        h, m = divmod(m, 60)
+    else:
+        micros = 0
+        s = 0
+        m = 0
+        h = y
+    tz = timezone(z)
+    original_tz = tz_aware_original_time.tzinfo
+    tz_naive_original_time = tz_aware_original_time.astimezone(tz).replace(tzinfo=None)
+    tz_naive_earlier_time = tz_naive_original_time.replace(
+        hour=h, minute=m, second=s, microsecond=micros
+    ) - timedelta(days=x)
+    tz_aware_earlier_time = tz.localize(tz_naive_earlier_time).astimezone(original_tz)
+    return tz_aware_earlier_time

--- a/timely_beliefs/sensors/utils.py
+++ b/timely_beliefs/sensors/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from inspect import getfullargspec, getmembers, isfunction
-from typing import Optional, Tuple, Union
+from typing import Tuple, Union
 
 import pandas as pd
 from isodate import (

--- a/timely_beliefs/sensors/utils.py
+++ b/timely_beliefs/sensors/utils.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from inspect import getfullargspec, getmembers, isfunction
 from typing import Optional, Tuple, Union
 
+import pandas as pd
 from isodate import (
     ISO8601Error,
     datetime_isoformat,
@@ -59,7 +62,7 @@ FUNC_STORE: dict = {
 def eval_verified_knowledge_horizon_fnc(
     requested_fnc_name: str,
     par: dict,
-    event_start: Optional[datetime] = None,
+    event_start: datetime | pd.DatetimeIndex | None = None,
     event_resolution: timedelta = None,
     get_bounds: bool = False,
 ) -> Union[timedelta, Tuple[timedelta, timedelta]]:
@@ -76,7 +79,7 @@ def eval_verified_knowledge_horizon_fnc(
                     event_start,
                     event_resolution,
                     **(unjsonify_time_dict(par)),
-                    get_bounds=get_bounds
+                    get_bounds=get_bounds,
                 )
             elif "event_start" in verified_fnc_specs["args"]:
                 # Knowledge horizons are anchored to event_start
@@ -88,7 +91,7 @@ def eval_verified_knowledge_horizon_fnc(
                 return verified_fnc(
                     event_resolution,
                     **(unjsonify_time_dict(par)),
-                    get_bounds=get_bounds
+                    get_bounds=get_bounds,
                 )
     raise Exception(
         "knowledge_horizon_fnc %s cannot be executed safely. Please register the function in the func_store."

--- a/timely_beliefs/sensors/utils.py
+++ b/timely_beliefs/sensors/utils.py
@@ -46,10 +46,14 @@ def unjsonify_time_dict(d: dict) -> dict:
     return d2
 
 
-def get_func_store() -> dict:
-    """Returns a dictionary with Callable objects supported in our function store,
-    indexed by their function names."""
-    return {o[0]: o[1] for o in getmembers(knowledge_horizons) if isfunction(o[1])}
+# A dictionary with function specification (incl. Callable objects) supported in our function store, indexed by their function names.
+FUNC_STORE: dict = {
+    o[0]: {
+        "fnc": o[1],
+        "args": getfullargspec(o[1]).args,
+    }
+    for o in getmembers(knowledge_horizons, isfunction)
+}
 
 
 def eval_verified_knowledge_horizon_fnc(
@@ -63,11 +67,10 @@ def eval_verified_knowledge_horizon_fnc(
     Only function names that represent Callable objects in our function store can be evaluated.
     If get_bounds is True, a tuple is returned with bounds on the possible return value.
     """
-    for verified_fnc_name, verified_fnc in get_func_store().items():
+    for verified_fnc_name, verified_fnc_specs in FUNC_STORE.items():
+        verified_fnc = verified_fnc_specs["fnc"]
         if verified_fnc_name == requested_fnc_name:
-            if {"event_start", "event_resolution"} < set(
-                getfullargspec(verified_fnc).args
-            ):
+            if {"event_start", "event_resolution"} < set(verified_fnc_specs["args"]):
                 # Knowledge horizons are anchored to event_end = event_start + event_resolution
                 return verified_fnc(
                     event_start,
@@ -75,12 +78,12 @@ def eval_verified_knowledge_horizon_fnc(
                     **(unjsonify_time_dict(par)),
                     get_bounds=get_bounds
                 )
-            elif "event_start" in getfullargspec(verified_fnc).args:
+            elif "event_start" in verified_fnc_specs["args"]:
                 # Knowledge horizons are anchored to event_start
                 return verified_fnc(
                     event_start, **(unjsonify_time_dict(par)), get_bounds=get_bounds
                 )
-            elif "event_resolution" in getfullargspec(verified_fnc).args:
+            elif "event_resolution" in verified_fnc_specs["args"]:
                 # Knowledge horizons are anchored to event_start
                 return verified_fnc(
                     event_resolution,

--- a/timely_beliefs/sensors/utils.py
+++ b/timely_beliefs/sensors/utils.py
@@ -11,9 +11,9 @@ from isodate import (
 )
 
 from timely_beliefs.sensors.func_store import knowledge_horizons
-from timely_beliefs.sensors.func_store.utils import (  # noqa F401
+from timely_beliefs.sensors.func_store.utils import (  # noqa F401; third parties may have historically imported datetime_x_days_ago_at_y_oclock from here
     datetime_x_days_ago_at_y_oclock,
-)  # third parties may have historically imported datetime_x_days_ago_at_y_oclock from here
+)
 
 
 def jsonify_time_dict(d: dict) -> dict:

--- a/timely_beliefs/sensors/utils.py
+++ b/timely_beliefs/sensors/utils.py
@@ -9,33 +9,11 @@ from isodate import (
     parse_datetime,
     parse_duration,
 )
-from pytz import timezone
 
 from timely_beliefs.sensors.func_store import knowledge_horizons
-
-
-def datetime_x_days_ago_at_y_oclock(
-    tz_aware_original_time: datetime, x: int, y: Union[int, float], z: str
-) -> datetime:
-    """Returns the datetime x days ago a y o'clock as determined from the perspective of timezone z."""
-    if isinstance(y, float):
-        micros = int(y * 60 * 60 * 10**6)
-        s, micros = divmod(micros, 10**6)
-        m, s = divmod(s, 60)
-        h, m = divmod(m, 60)
-    else:
-        micros = 0
-        s = 0
-        m = 0
-        h = y
-    tz = timezone(z)
-    original_tz = tz_aware_original_time.tzinfo
-    tz_naive_original_time = tz_aware_original_time.astimezone(tz).replace(tzinfo=None)
-    tz_naive_earlier_time = tz_naive_original_time.replace(
-        hour=h, minute=m, second=s, microsecond=micros
-    ) - timedelta(days=x)
-    tz_aware_earlier_time = tz.localize(tz_naive_earlier_time).astimezone(original_tz)
-    return tz_aware_earlier_time
+from timely_beliefs.sensors.func_store.utils import (  # noqa F401
+    datetime_x_days_ago_at_y_oclock,
+)  # third parties may have historically imported datetime_x_days_ago_at_y_oclock from here
 
 
 def jsonify_time_dict(d: dict) -> dict:

--- a/timely_beliefs/tests/conftest.py
+++ b/timely_beliefs/tests/conftest.py
@@ -68,17 +68,20 @@ def time_slot_sensor(db):
 @pytest.fixture(scope="function", autouse=True)
 def ex_post_time_slot_sensor(db):
     """Define sensor for time slot events known in advance (ex post)."""
+    # todo: this function name, docstring and sensor name is wrong: the correct knowledge horizon is x_days_ago_at_y_oclock (which is actually very much ex ante)
     return create_ex_post_time_slot_sensor("ExPostSensor")
 
 
 @pytest.fixture(scope="function", autouse=False)
 def ex_post_time_slot_sensor_b(db):
     """Define an almost identical ex-post time slot sensor, just with a different name."""
+    # todo: this function name, docstring and sensor name is wrong: the correct knowledge horizon is x_days_ago_at_y_oclock (which is actually very much ex ante)
     return create_ex_post_time_slot_sensor("ExPostSensor B")
 
 
 def create_ex_post_time_slot_sensor(name: str) -> DBSensor:
     """Define sensor for time slot events known in advance (ex post)."""
+    # todo: this function name and docstring is wrong: the correct knowledge horizon is x_days_ago_at_y_oclock (which is actually very much ex ante)
     sensor = DBSensor(
         name=name,
         event_resolution=timedelta(minutes=15),

--- a/timely_beliefs/tests/conftest.py
+++ b/timely_beliefs/tests/conftest.py
@@ -10,6 +10,7 @@ from timely_beliefs.db_base import Base
 from timely_beliefs.sensors.func_store.knowledge_horizons import (
     at_date,
     determine_ex_ante_knowledge_horizon_for_x_days_ago_at_y_oclock,
+    ex_post,
 )
 from timely_beliefs.tests import engine, session
 
@@ -66,28 +67,40 @@ def time_slot_sensor(db):
 
 
 @pytest.fixture(scope="function", autouse=True)
-def ex_post_time_slot_sensor(db):
-    """Define sensor for time slot events known in advance (ex post)."""
-    # todo: this function name, docstring and sensor name is wrong: the correct knowledge horizon is x_days_ago_at_y_oclock (which is actually very much ex ante)
-    return create_ex_post_time_slot_sensor("ExPostSensor")
+def ex_ante_economics_sensor(db):
+    """Define sensor for time slot events known in advance (ex ante)."""
+    return create_ex_ante_economics_sensor("ex-ante sensor A")
 
 
 @pytest.fixture(scope="function", autouse=False)
-def ex_post_time_slot_sensor_b(db):
-    """Define an almost identical ex-post time slot sensor, just with a different name."""
-    # todo: this function name, docstring and sensor name is wrong: the correct knowledge horizon is x_days_ago_at_y_oclock (which is actually very much ex ante)
-    return create_ex_post_time_slot_sensor("ExPostSensor B")
+def ex_ante_economics_sensor_b(db):
+    """Define an almost identical ex-ante time slot sensor, just with a different name."""
+    return create_ex_ante_economics_sensor("ex-ante sensor B")
 
 
-def create_ex_post_time_slot_sensor(name: str) -> DBSensor:
-    """Define sensor for time slot events known in advance (ex post)."""
-    # todo: this function name and docstring is wrong: the correct knowledge horizon is x_days_ago_at_y_oclock (which is actually very much ex ante)
+def create_ex_ante_economics_sensor(name: str) -> DBSensor:
+    """Define sensor for economical events known in advance (ex ante)."""
     sensor = DBSensor(
         name=name,
         event_resolution=timedelta(minutes=15),
         knowledge_horizon=(
             determine_ex_ante_knowledge_horizon_for_x_days_ago_at_y_oclock,
             dict(x=1, y=12, z="Europe/Amsterdam"),
+        ),
+    )
+    session.add(sensor)
+    session.flush()
+    return sensor
+
+
+def create_ex_post_physics_sensor(name: str) -> DBSensor:
+    """Define sensor for physical events known after the fact (ex post)."""
+    sensor = DBSensor(
+        name=name,
+        event_resolution=timedelta(minutes=15),
+        knowledge_horizon=(
+            ex_post,
+            dict(event_resolution=timedelta(minutes=15), ex_post_horizon=timedelta(0)),
         ),
     )
     session.add(sensor)

--- a/timely_beliefs/tests/test_belief_init.py
+++ b/timely_beliefs/tests/test_belief_init.py
@@ -36,13 +36,13 @@ def day_ahead_belief_about_time_slot_event(
 
 
 @pytest.fixture(scope="function")
-def day_ahead_belief_about_ex_post_time_slot_event(
-    ex_post_time_slot_sensor: Sensor, test_source_a: BeliefSource
+def day_ahead_belief_about_ex_ante_economical_event(
+    ex_ante_economics_sensor: Sensor, test_source_a: BeliefSource
 ):
-    """Define day-ahead belief about an ex post time slot event."""
+    """Define day-ahead belief about an ex-ante economical event."""
     return TimedBelief(
         source=test_source_a,
-        sensor=ex_post_time_slot_sensor,
+        sensor=ex_ante_economics_sensor,
         value=1,
         belief_time=datetime(2018, 1, 1, 15, tzinfo=utc),
         event_start=datetime(2018, 1, 2, 0, tzinfo=utc),
@@ -74,19 +74,19 @@ def test_day_ahead_belief_about_time_slot_event(
     )
 
 
-def test_day_ahead_belief_about_ex_post_time_slot_event(
-    day_ahead_belief_about_ex_post_time_slot_event: TimedBelief,
+def test_day_ahead_belief_about_ex_ante_economical_event(
+    day_ahead_belief_about_ex_ante_economical_event: TimedBelief,
 ):
-    assert day_ahead_belief_about_ex_post_time_slot_event.knowledge_time == datetime(
+    assert day_ahead_belief_about_ex_ante_economical_event.knowledge_time == datetime(
         2018, 1, 1, 11, tzinfo=utc
     )
-    assert day_ahead_belief_about_ex_post_time_slot_event.belief_horizon == -timedelta(
+    assert day_ahead_belief_about_ex_ante_economical_event.belief_horizon == -timedelta(
         hours=4
     )
-    assert day_ahead_belief_about_ex_post_time_slot_event.belief_horizon == timedelta(
+    assert day_ahead_belief_about_ex_ante_economical_event.belief_horizon == timedelta(
         hours=9
-    ) - day_ahead_belief_about_ex_post_time_slot_event.sensor.knowledge_horizon(
-        day_ahead_belief_about_ex_post_time_slot_event.event_start
+    ) - day_ahead_belief_about_ex_ante_economical_event.sensor.knowledge_horizon(
+        day_ahead_belief_about_ex_ante_economical_event.event_start
     )
 
 

--- a/timely_beliefs/tests/test_belief_query.py
+++ b/timely_beliefs/tests/test_belief_query.py
@@ -56,13 +56,13 @@ def test_query_belief_for_sensor_with_unique_knowledge_time(
 
 
 @pytest.fixture(scope="function")
-def day_ahead_belief_about_ex_post_time_slot_event(
-    ex_post_time_slot_sensor: DBSensor, test_source_a: DBBeliefSource
+def day_ahead_belief_about_ex_ante_economical_event(
+    ex_ante_economics_sensor: DBSensor, test_source_a: DBBeliefSource
 ):
-    """Define day-ahead belief about an ex post time slot event."""
+    """Define day-ahead belief about an ex-ante economical event."""
     belief = DBTimedBelief(
         source=test_source_a,
-        sensor=ex_post_time_slot_sensor,
+        sensor=ex_ante_economics_sensor,
         value=10,
         belief_time=datetime(2018, 1, 1, 10, tzinfo=utc),
         event_start=datetime(2018, 1, 2, 22, 45, tzinfo=utc),
@@ -72,19 +72,19 @@ def day_ahead_belief_about_ex_post_time_slot_event(
 
 
 @pytest.fixture(scope="function")
-def multiple_day_ahead_beliefs_about_ex_post_time_slot_event(
-    ex_post_time_slot_sensor: DBSensor, test_source_a: DBBeliefSource
+def multiple_day_ahead_beliefs_about_ex_ante_economical_event(
+    ex_ante_economics_sensor: DBSensor, test_source_a: DBBeliefSource
 ):
-    """Define multiple day-ahead beliefs about an ex post time slot event."""
+    """Define multiple day-ahead beliefs about an ex-ante economical event."""
     n = 10
     event_start = datetime(2025, 1, 2, 22, 45, tzinfo=utc)
     beliefs = []
     for i in range(n):
         belief = DBTimedBelief(
             source=test_source_a,
-            sensor=ex_post_time_slot_sensor,
+            sensor=ex_ante_economics_sensor,
             value=10 + i,
-            belief_time=ex_post_time_slot_sensor.knowledge_time(event_start)
+            belief_time=ex_ante_economics_sensor.knowledge_time(event_start)
             - timedelta(hours=i + 1),
             event_start=event_start,
         )
@@ -94,20 +94,20 @@ def multiple_day_ahead_beliefs_about_ex_post_time_slot_event(
 
 
 @pytest.fixture(scope="function")
-def multiple_probabilistic_day_ahead_beliefs_about_ex_post_time_slot_event(
-    ex_post_time_slot_sensor: DBSensor,
-    ex_post_time_slot_sensor_b: DBSensor,
+def multiple_probabilistic_day_ahead_beliefs_about_ex_ante_economical_event(
+    ex_ante_economics_sensor: DBSensor,
+    ex_ante_economics_sensor_b: DBSensor,
     test_source_a: DBBeliefSource,
 ):
-    """Define multiple probabilistic day-ahead beliefs about an ex post time slot event on two sensors."""
+    """Define multiple probabilistic day-ahead beliefs about an ex-ante economical event on two sensors."""
     n = 10  # number of belief times
     np = 2  # number of probabilities per belief
     event_start = datetime(2025, 1, 2, 22, 45, tzinfo=utc)
     beliefs = []
-    for sensor in [ex_post_time_slot_sensor, ex_post_time_slot_sensor_b]:
+    for sensor in [ex_ante_economics_sensor, ex_ante_economics_sensor_b]:
         for i in range(n):
             for j in range(np):
-                if sensor == ex_post_time_slot_sensor and i == 0:
+                if sensor == ex_ante_economics_sensor and i == 0:
                     # Skip to ensure that sensor B has more recent beliefs
                     # This is to test the most_recent_only parameter for a query on the other sensor
                     continue
@@ -115,7 +115,7 @@ def multiple_probabilistic_day_ahead_beliefs_about_ex_post_time_slot_event(
                     source=test_source_a,
                     sensor=sensor,
                     value=10 + i - j / 100,
-                    belief_time=ex_post_time_slot_sensor.knowledge_time(event_start)
+                    belief_time=ex_ante_economics_sensor.knowledge_time(event_start)
                     - timedelta(hours=i + 1),
                     event_start=event_start,
                     cumulative_probability=0.5 * (1 - j / np),
@@ -126,19 +126,19 @@ def multiple_probabilistic_day_ahead_beliefs_about_ex_post_time_slot_event(
 
 
 @pytest.fixture(scope="function")
-def multiple_day_after_beliefs_about_ex_post_time_slot_event(
-    ex_post_time_slot_sensor: DBSensor, test_source_a: DBBeliefSource
+def multiple_day_after_beliefs_about_ex_ante_economical_event(
+    ex_ante_economics_sensor: DBSensor, test_source_a: DBBeliefSource
 ):
-    """Define multiple day-after beliefs about an ex post time slot event."""
+    """Define multiple day-after beliefs about an ex-ante economical event."""
     n = 10
     event_start = datetime(2025, 1, 2, 23, 00, tzinfo=utc)
     beliefs = []
     for i in range(n):
         belief = DBTimedBelief(
             source=test_source_a,
-            sensor=ex_post_time_slot_sensor,
+            sensor=ex_ante_economics_sensor,
             value=10 + i,
-            belief_time=ex_post_time_slot_sensor.knowledge_time(event_start)
+            belief_time=ex_ante_economics_sensor.knowledge_time(event_start)
             + timedelta(hours=i + 1),
             event_start=event_start,
         )
@@ -148,24 +148,24 @@ def multiple_day_after_beliefs_about_ex_post_time_slot_event(
 
 
 def test_query_belief_with_empty_source_list(
-    ex_post_time_slot_sensor: DBSensor,
-    day_ahead_belief_about_ex_post_time_slot_event: DBTimedBelief,
+    ex_ante_economics_sensor: DBSensor,
+    day_ahead_belief_about_ex_ante_economical_event: DBTimedBelief,
 ):
     belief_df = DBTimedBelief.search_session(
         session=session,
-        sensor=ex_post_time_slot_sensor,
+        sensor=ex_ante_economics_sensor,
         source=[],
     )
     assert belief_df.empty
 
 
 def test_query_belief_by_belief_time(
-    ex_post_time_slot_sensor: DBSensor,
-    day_ahead_belief_about_ex_post_time_slot_event: DBTimedBelief,
+    ex_ante_economics_sensor: DBSensor,
+    day_ahead_belief_about_ex_ante_economical_event: DBTimedBelief,
 ):
     belief_df = DBTimedBelief.search_session(
         session=session,
-        sensor=ex_post_time_slot_sensor,
+        sensor=ex_ante_economics_sensor,
         beliefs_before=datetime(2018, 1, 1, 13, tzinfo=utc),
     )
 
@@ -187,7 +187,7 @@ def test_query_belief_by_belief_time(
         len(
             DBTimedBelief.search_session(
                 session=session,
-                sensor=ex_post_time_slot_sensor,
+                sensor=ex_ante_economics_sensor,
                 beliefs_before=datetime(2017, 1, 1, 10, tzinfo=utc),
             ).index
         )
@@ -199,7 +199,7 @@ def test_query_belief_by_belief_time(
         len(
             DBTimedBelief.search_session(
                 session=session,
-                sensor=ex_post_time_slot_sensor,
+                sensor=ex_ante_economics_sensor,
                 beliefs_after=datetime(2018, 1, 3, 10, tzinfo=utc),
             ).index
         )
@@ -211,7 +211,7 @@ def test_query_belief_by_belief_time(
         len(
             DBTimedBelief.search_session(
                 session=session,
-                sensor=ex_post_time_slot_sensor,
+                sensor=ex_ante_economics_sensor,
                 beliefs_after=datetime(2018, 1, 1, 10, tzinfo=utc),
             ).index
         )
@@ -223,7 +223,7 @@ def test_query_belief_by_belief_time(
         len(
             DBTimedBelief.search_session(
                 session=session,
-                sensor=ex_post_time_slot_sensor,
+                sensor=ex_ante_economics_sensor,
                 beliefs_before=datetime(2018, 1, 1, 9, tzinfo=utc),
             ).index
         )
@@ -235,7 +235,7 @@ def test_query_belief_by_belief_time(
         len(
             DBTimedBelief.search_session(
                 session=session,
-                sensor=ex_post_time_slot_sensor,
+                sensor=ex_ante_economics_sensor,
                 beliefs_after=datetime(2018, 1, 1, 13, tzinfo=utc),
             ).index
         )
@@ -244,10 +244,10 @@ def test_query_belief_by_belief_time(
 
 
 def test_query_belief_history(
-    ex_post_time_slot_sensor: DBSensor,
-    multiple_day_ahead_beliefs_about_ex_post_time_slot_event: list[DBTimedBelief],
+    ex_ante_economics_sensor: DBSensor,
+    multiple_day_ahead_beliefs_about_ex_ante_economical_event: list[DBTimedBelief],
 ):
-    df = DBTimedBelief.search_session(session=session, sensor=ex_post_time_slot_sensor)
+    df = DBTimedBelief.search_session(session=session, sensor=ex_ante_economics_sensor)
     event_start = datetime(2025, 1, 2, 22, 45, tzinfo=utc)
     df2 = df.belief_history(event_start).sort_index(
         level="belief_time", ascending=False
@@ -357,34 +357,34 @@ def _test_empty_frame(time_slot_sensor):
 
 
 def test_search_by_sensor_id(
-    ex_post_time_slot_sensor: DBSensor,
-    multiple_day_ahead_beliefs_about_ex_post_time_slot_event: list[DBTimedBelief],
+    ex_ante_economics_sensor: DBSensor,
+    multiple_day_ahead_beliefs_about_ex_ante_economical_event: list[DBTimedBelief],
 ):
     """Check db query by sensor id, against query by sensor instance, for a non-empty dataset."""
 
     # Query all beliefs for this sensor, using sensor instance (our reference)
     df_by_instance = DBTimedBelief.search_session(
-        session=session, sensor=ex_post_time_slot_sensor, most_recent_only=False
+        session=session, sensor=ex_ante_economics_sensor, most_recent_only=False
     )
 
     # Query all beliefs for this sensor, using sensor id (our test)
     df_by_id = DBTimedBelief.search_session(
-        session=session, sensor=ex_post_time_slot_sensor.id, most_recent_only=False
+        session=session, sensor=ex_ante_economics_sensor.id, most_recent_only=False
     )
     assert not df_by_id.empty
     pd.testing.assert_frame_equal(df_by_id, df_by_instance)
 
 
 def test_select_most_recent_deterministic_beliefs(
-    ex_post_time_slot_sensor: DBSensor,
-    multiple_day_ahead_beliefs_about_ex_post_time_slot_event: list[DBTimedBelief],
-    multiple_day_after_beliefs_about_ex_post_time_slot_event: list[DBTimedBelief],
+    ex_ante_economics_sensor: DBSensor,
+    multiple_day_ahead_beliefs_about_ex_ante_economical_event: list[DBTimedBelief],
+    multiple_day_after_beliefs_about_ex_ante_economical_event: list[DBTimedBelief],
 ):
     """Check db query filters for most recent beliefs, most recent events, and both at once."""
 
     # Query all beliefs for this sensor
     df = DBTimedBelief.search_session(
-        session=session, sensor=ex_post_time_slot_sensor, most_recent_only=False
+        session=session, sensor=ex_ante_economics_sensor, most_recent_only=False
     )
 
     # Most recent beliefs selected after query (our reference)
@@ -392,7 +392,7 @@ def test_select_most_recent_deterministic_beliefs(
 
     # Most recent beliefs selected within query (our test)
     df_recent_beliefs_within_query = DBTimedBelief.search_session(
-        session=session, sensor=ex_post_time_slot_sensor, most_recent_only=True
+        session=session, sensor=ex_ante_economics_sensor, most_recent_only=True
     )
     pd.testing.assert_frame_equal(
         df_recent_beliefs_within_query, df_recent_beliefs_after_query
@@ -405,7 +405,7 @@ def test_select_most_recent_deterministic_beliefs(
 
     # Most recent events selected within query (our test)
     df_recent_events_within_query = DBTimedBelief.search_session(
-        session=session, sensor=ex_post_time_slot_sensor, most_recent_events_only=True
+        session=session, sensor=ex_ante_economics_sensor, most_recent_events_only=True
     )
     pd.testing.assert_frame_equal(
         df_recent_events_within_query, df_recent_events_after_query
@@ -420,7 +420,7 @@ def test_select_most_recent_deterministic_beliefs(
     # Most recent beliefs and most recent events selected within query (our test)
     df_recent_both_within_query = DBTimedBelief.search_session(
         session=session,
-        sensor=ex_post_time_slot_sensor,
+        sensor=ex_ante_economics_sensor,
         most_recent_only=True,
         most_recent_events_only=True,
     )
@@ -430,17 +430,17 @@ def test_select_most_recent_deterministic_beliefs(
 
 
 def test_select_most_recent_probabilistic_beliefs(
-    ex_post_time_slot_sensor: DBSensor,
-    multiple_probabilistic_day_ahead_beliefs_about_ex_post_time_slot_event: list[
+    ex_ante_economics_sensor: DBSensor,
+    multiple_probabilistic_day_ahead_beliefs_about_ex_ante_economical_event: list[
         DBTimedBelief
     ],
 ):
     df = DBTimedBelief.search_session(
-        session=session, sensor=ex_post_time_slot_sensor, most_recent_only=False
+        session=session, sensor=ex_ante_economics_sensor, most_recent_only=False
     )
     most_recent_df = belief_utils.select_most_recent_belief(df)
     df = DBTimedBelief.search_session(
-        session=session, sensor=ex_post_time_slot_sensor, most_recent_only=True
+        session=session, sensor=ex_ante_economics_sensor, most_recent_only=True
     )
     pd.testing.assert_frame_equal(df, most_recent_df)
 

--- a/timely_beliefs/tests/test_belief_query.py
+++ b/timely_beliefs/tests/test_belief_query.py
@@ -163,64 +163,57 @@ def test_query_belief_by_belief_time(
     ex_ante_economics_sensor: DBSensor,
     day_ahead_belief_about_ex_ante_economical_event: DBTimedBelief,
 ):
-    belief_df = DBTimedBelief.search_session(
-        session=session,
-        sensor=ex_ante_economics_sensor,
-        beliefs_before=datetime(2018, 1, 1, 13, tzinfo=utc),
-    )
+    test_cases = [
+        # Just one belief set up for this sensor
+        dict(
+            expected_length=1,
+        ),
+        # No beliefs a year earlier
+        dict(
+            beliefs_before=datetime(2017, 1, 1, 10, tzinfo=utc),
+            expected_length=0,
+        ),
+        # No beliefs 2 months later
+        dict(
+            beliefs_after=datetime(2018, 1, 3, 10, tzinfo=utc),
+            expected_length=0,
+        ),
+        # One belief after 10am UTC
+        dict(
+            beliefs_after=datetime(2018, 1, 1, 10, tzinfo=utc),
+            expected_length=1,
+        ),
+        # No beliefs an hour earlier
+        dict(
+            beliefs_before=datetime(2018, 1, 1, 9, tzinfo=utc),
+            expected_length=0,
+        ),
+        # No beliefs after 1pm UTC
+        dict(
+            beliefs_after=datetime(2018, 1, 1, 13, tzinfo=utc),
+            expected_length=0,
+        ),
+    ]
 
-    # By calling a pandas Series for its values we lose the timezone (a pandas bug still present in version 0.23.4)
-    # This next test warns us when it has been fixed (if it fails, just replace != with ==).
-    assert belief_df.knowledge_times.values[0] != datetime(
-        2018, 1, 1, 11, 0, tzinfo=utc
-    )
-    # And this test is just a workaround to test what we wanted to test.
-    assert pd.Timestamp(belief_df.knowledge_times.values[0]) == pd.Timestamp(
-        datetime(2018, 1, 1, 11, 0)
-    )
-
-    # Just one belief found
-    assert len(belief_df) == 1
-
-    # No beliefs a year earlier
-    assert DBTimedBelief.search_session(
-        session=session,
-        sensor=ex_ante_economics_sensor,
-        beliefs_before=datetime(2017, 1, 1, 10, tzinfo=utc),
-    ).empty
-
-    # No beliefs 2 months later
-    assert DBTimedBelief.search_session(
-        session=session,
-        sensor=ex_ante_economics_sensor,
-        beliefs_after=datetime(2018, 1, 3, 10, tzinfo=utc),
-    ).empty
-
-    # One belief after 10am UTC
-    assert (
-        len(
-            DBTimedBelief.search_session(
-                session=session,
-                sensor=ex_ante_economics_sensor,
-                beliefs_after=datetime(2018, 1, 1, 10, tzinfo=utc),
-            )
+    for test_case in test_cases:
+        bdf = DBTimedBelief.search_session(
+            session=session,
+            sensor=ex_ante_economics_sensor,
+            beliefs_after=test_case.get("beliefs_after"),
+            beliefs_before=test_case.get("beliefs_before"),
         )
-        == 1
-    )
+        assert len(bdf) == test_case.get("expected_length")
 
-    # No beliefs an hour earlier
-    assert DBTimedBelief.search_session(
-        session=session,
-        sensor=ex_ante_economics_sensor,
-        beliefs_before=datetime(2018, 1, 1, 9, tzinfo=utc),
-    ).empty
-
-    # No beliefs after 1pm UTC
-    assert DBTimedBelief.search_session(
-        session=session,
-        sensor=ex_ante_economics_sensor,
-        beliefs_after=datetime(2018, 1, 1, 13, tzinfo=utc),
-    ).empty
+        if test_case.get("expected_length") == 1:
+            # By calling a pandas Series for its values we lose the timezone (a pandas bug still present in version 0.23.4)
+            # This next test warns us when it has been fixed (if it fails, just replace != with ==).
+            assert bdf.knowledge_times.values[0] != datetime(
+                2018, 1, 1, 11, 0, tzinfo=utc
+            )
+            # And this test is just a workaround to test what we wanted to test.
+            assert pd.Timestamp(bdf.knowledge_times.values[0]) == pd.Timestamp(
+                datetime(2018, 1, 1, 11, 0)
+            )
 
 
 def test_query_belief_history(

--- a/timely_beliefs/tests/test_belief_query.py
+++ b/timely_beliefs/tests/test_belief_query.py
@@ -180,31 +180,21 @@ def test_query_belief_by_belief_time(
     )
 
     # Just one belief found
-    assert len(belief_df.index) == 1
+    assert len(belief_df) == 1
 
     # No beliefs a year earlier
-    assert (
-        len(
-            DBTimedBelief.search_session(
-                session=session,
-                sensor=ex_ante_economics_sensor,
-                beliefs_before=datetime(2017, 1, 1, 10, tzinfo=utc),
-            ).index
-        )
-        == 0
-    )
+    assert DBTimedBelief.search_session(
+        session=session,
+        sensor=ex_ante_economics_sensor,
+        beliefs_before=datetime(2017, 1, 1, 10, tzinfo=utc),
+    ).empty
 
     # No beliefs 2 months later
-    assert (
-        len(
-            DBTimedBelief.search_session(
-                session=session,
-                sensor=ex_ante_economics_sensor,
-                beliefs_after=datetime(2018, 1, 3, 10, tzinfo=utc),
-            ).index
-        )
-        == 0
-    )
+    assert DBTimedBelief.search_session(
+        session=session,
+        sensor=ex_ante_economics_sensor,
+        beliefs_after=datetime(2018, 1, 3, 10, tzinfo=utc),
+    ).empty
 
     # One belief after 10am UTC
     assert (
@@ -213,34 +203,24 @@ def test_query_belief_by_belief_time(
                 session=session,
                 sensor=ex_ante_economics_sensor,
                 beliefs_after=datetime(2018, 1, 1, 10, tzinfo=utc),
-            ).index
+            )
         )
         == 1
     )
 
     # No beliefs an hour earlier
-    assert (
-        len(
-            DBTimedBelief.search_session(
-                session=session,
-                sensor=ex_ante_economics_sensor,
-                beliefs_before=datetime(2018, 1, 1, 9, tzinfo=utc),
-            ).index
-        )
-        == 0
-    )
+    assert DBTimedBelief.search_session(
+        session=session,
+        sensor=ex_ante_economics_sensor,
+        beliefs_before=datetime(2018, 1, 1, 9, tzinfo=utc),
+    ).empty
 
     # No beliefs after 1pm UTC
-    assert (
-        len(
-            DBTimedBelief.search_session(
-                session=session,
-                sensor=ex_ante_economics_sensor,
-                beliefs_after=datetime(2018, 1, 1, 13, tzinfo=utc),
-            ).index
-        )
-        == 0
-    )
+    assert DBTimedBelief.search_session(
+        session=session,
+        sensor=ex_ante_economics_sensor,
+        beliefs_after=datetime(2018, 1, 1, 13, tzinfo=utc),
+    ).empty
 
 
 def test_query_belief_history(
@@ -348,7 +328,7 @@ def _test_empty_frame(time_slot_sensor):
         sensor=time_slot_sensor,
         beliefs_before=datetime(1900, 1, 1, 13, tzinfo=utc),
     )
-    assert len(bdf) == 0  # no data expected
+    assert bdf.empty  # no data expected
     assert pd.api.types.is_datetime64_dtype(bdf.index.get_level_values("belief_time"))
     bdf = bdf.convert_index_from_belief_time_to_horizon()
     assert pd.api.types.is_timedelta64_dtype(

--- a/timely_beliefs/tests/test_sensor_init.py
+++ b/timely_beliefs/tests/test_sensor_init.py
@@ -16,6 +16,6 @@ def test_time_slot_sensor(time_slot_sensor: DBSensor):
     assert time_slot_sensor.knowledge_time(event_start) == event_end
 
 
-def test_ex_post_time_slot_sensor(ex_post_time_slot_sensor: DBSensor):
+def test_ex_ante_economics_sensor(ex_ante_economics_sensor: DBSensor):
     event_start = datetime(2018, 1, 1, 15, tzinfo=utc)
-    assert ex_post_time_slot_sensor.knowledge_time(event_start) < event_start
+    assert ex_ante_economics_sensor.knowledge_time(event_start) < event_start


### PR DESCRIPTION
Much needed vectorization.

- [x] Need to resolve some todos.
- [x] Want to add tests for ex_post and ex_ante knowledge horizon functions. Especially the ex_post, because it is the most common. We're only testing the most difficult ones right now.