### PR TITLE
Use value_counts()

### DIFF
--- a/timely_beliefs/beliefs/__init__.py
+++ b/timely_beliefs/beliefs/__init__.py
@@ -119,8 +119,8 @@ class BeliefsAccessor(object):
     @property
     def number_of_probabilistic_beliefs(self) -> int:
         """Return the number of beliefs in the BeliefsDataFrame that are probabilistic (more than 1 unique value)."""
-        df = self._obj.for_each_belief(fnc=pd.DataFrame.nunique, dropna=True)
-        return len(df[df > 1].max(axis=1).dropna())
+        p_depth = self._obj.droplevel("cumulative_probability").index.value_counts()
+        return len(p_depth[p_depth > 1])
 
     @property
     def number_of_deterministic_beliefs(self) -> int:

--- a/timely_beliefs/beliefs/__init__.py
+++ b/timely_beliefs/beliefs/__init__.py
@@ -8,7 +8,6 @@ Below, we register customer accessors.
 from datetime import datetime, timedelta
 from typing import List
 
-import pandas as pd
 from pandas.api.extensions import register_dataframe_accessor
 
 
@@ -103,7 +102,7 @@ class BeliefsAccessor(object):
     def number_of_beliefs(self) -> int:
         """Return the total number of beliefs in the BeliefsDataFrame, including both deterministic beliefs (which
         require a single row) and probabilistic beliefs (which require multiple rows)."""
-        return len(self._obj.droplevel("cumulative_probability").index.unique())
+        return len(self._obj.probabilistic_depth_per_belief)
 
     @property
     def sources(self) -> List[int]:
@@ -119,23 +118,22 @@ class BeliefsAccessor(object):
     @property
     def number_of_probabilistic_beliefs(self) -> int:
         """Return the number of beliefs in the BeliefsDataFrame that are probabilistic (more than 1 unique value)."""
-        return len(self._obj) - self.number_of_deterministic_beliefs
+        return self.number_of_beliefs - self.number_of_deterministic_beliefs
 
     @property
     def number_of_deterministic_beliefs(self) -> int:
         """Return the number of beliefs in the BeliefsDataFrame that are deterministic (1 unique value)."""
-        p_depth = self._obj.droplevel("cumulative_probability").index.value_counts()
-        return len(p_depth[p_depth == 1])
+        return self._obj.probabilistic_depth_count.get(1, 0)
 
     @property
     def percentage_of_probabilistic_beliefs(self) -> float:
         """Return the percentage of beliefs in the BeliefsDataFrame that are probabilistic (more than 1 unique value)."""
-        return self.number_of_probabilistic_beliefs / self.number_of_beliefs
+        return 1 - self.percentage_of_deterministic_beliefs
 
     @property
     def percentage_of_deterministic_beliefs(self) -> float:
         """Return the percentage of beliefs in the BeliefsDataFrame that are deterministic (1 unique value)."""
-        return 1 - self.number_of_probabilistic_beliefs / self.number_of_beliefs
+        return self.number_of_deterministic_beliefs / self.number_of_beliefs
 
     @property
     def unique_beliefs_per_event_per_source(self) -> bool:

--- a/timely_beliefs/beliefs/__init__.py
+++ b/timely_beliefs/beliefs/__init__.py
@@ -127,12 +127,20 @@ class BeliefsAccessor(object):
 
     @property
     def percentage_of_probabilistic_beliefs(self) -> float:
-        """Return the percentage of beliefs in the BeliefsDataFrame that are probabilistic (more than 1 unique value)."""
+        """Return the percentage of beliefs in the BeliefsDataFrame that are probabilistic (more than 1 unique value).
+
+        Empty frames default to 0.
+        """
         return 1 - self.percentage_of_deterministic_beliefs
 
     @property
     def percentage_of_deterministic_beliefs(self) -> float:
-        """Return the percentage of beliefs in the BeliefsDataFrame that are deterministic (1 unique value)."""
+        """Return the percentage of beliefs in the BeliefsDataFrame that are deterministic (1 unique value).
+
+        Empty frames default to 1.
+        """
+        if len(self._obj) == 0:
+            return 1
         return self.number_of_deterministic_beliefs / self.number_of_beliefs
 
     @property

--- a/timely_beliefs/beliefs/__init__.py
+++ b/timely_beliefs/beliefs/__init__.py
@@ -119,13 +119,13 @@ class BeliefsAccessor(object):
     @property
     def number_of_probabilistic_beliefs(self) -> int:
         """Return the number of beliefs in the BeliefsDataFrame that are probabilistic (more than 1 unique value)."""
-        p_depth = self._obj.droplevel("cumulative_probability").index.value_counts()
-        return len(p_depth[p_depth > 1])
+        return len(self._obj) - self.number_of_deterministic_beliefs
 
     @property
     def number_of_deterministic_beliefs(self) -> int:
         """Return the number of beliefs in the BeliefsDataFrame that are deterministic (1 unique value)."""
-        return len(self._obj) - self.number_of_probabilistic_beliefs
+        p_depth = self._obj.droplevel("cumulative_probability").index.value_counts()
+        return len(p_depth[p_depth == 1])
 
     @property
     def percentage_of_probabilistic_beliefs(self) -> float:

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -24,6 +24,7 @@ import pandas as pd
 import pytz
 from pandas.core.groupby import DataFrameGroupBy
 from pandas.tseries.frequencies import to_offset
+from pandas.util._decorators import cache_readonly
 from sqlalchemy import (
     Column,
     DateTime,
@@ -1067,6 +1068,27 @@ class BeliefsDataFrame(pd.DataFrame):
                 probabilistic_utils.set_truth, reference_source
             )
         )
+
+    @cache_readonly
+    def probabilistic_depth_per_belief(self):
+        """Return the number of probabilistic values per belief."""
+        return self.droplevel("cumulative_probability").index.value_counts()
+
+    @cache_readonly
+    def probabilistic_depth_count(self):
+        """Return a count of the number of probabilistic values per belief.
+
+        For example, this frame contains 8 beliefs described by 3 probabilistic values,
+        and another 8 described by 2 probabilistic values.
+
+        >>> from timely_beliefs.examples.beliefs_data_frames import sixteen_probabilistic_beliefs
+        >>> sixteen_probabilistic_beliefs().probabilistic_depth_count
+        count
+        3    8
+        2    8
+        Name: count, dtype: int64
+        """
+        return self.probabilistic_depth_per_belief.value_counts()
 
     @property
     def event_frequency(self) -> Optional[timedelta]:

--- a/timely_beliefs/tests/test_df_resampling.py
+++ b/timely_beliefs/tests/test_df_resampling.py
@@ -254,12 +254,22 @@ def test_percentages_and_accuracy_of_probabilistic_model(df_4323: BeliefsDataFra
     assert df.lineage.percentage_of_probabilistic_beliefs == 1
     assert df.lineage.percentage_of_deterministic_beliefs == 0
     assert df.lineage.probabilistic_depth == 3
+    assert df.lineage.probabilistic_depth == df.probabilistic_depth_per_belief.mean()
 
     df = sixteen_probabilistic_beliefs()
     assert df.lineage.number_of_probabilistic_beliefs == 16
     assert df.lineage.percentage_of_probabilistic_beliefs == 1
     assert df.lineage.percentage_of_deterministic_beliefs == 0
     assert df.lineage.probabilistic_depth == (8 * 3 + 8 * 2) / 16
+    assert df.lineage.probabilistic_depth == df.probabilistic_depth_per_belief.mean()
+
+    # Check lineage is updated even in case of an inplace operation
+    df.drop(df.head(20).index, inplace=True)
+    assert df.lineage.number_of_probabilistic_beliefs == 8
+    assert df.lineage.percentage_of_probabilistic_beliefs == 1
+    assert df.lineage.percentage_of_deterministic_beliefs == 0
+    assert df.lineage.probabilistic_depth == (4 * 3 + 4 * 2) / 8
+    assert df.lineage.probabilistic_depth == df.probabilistic_depth_per_belief.mean()
 
 
 def test_downsample_once_upsample_once_around_dst(


### PR DESCRIPTION
This PR gets rid of another occurrence of using the `for_each_belief` method (which uses a `groupby` internally). It also makes sure that the underlying computation, which is now based on the faster `value_counts` method, is reused.

I wish I had discovered `df.droplevel("cumulative_probability").index.value_counts()` before. Likewise for Pandas' `cache_readonly`.