### PR TITLE
warn when the sensor attribute is not of type `Sensor`

### DIFF
--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -2192,6 +2192,18 @@ def set_columns_and_indices_for_empty_frame(df, columns, indices, default_types)
 
 def assign_sensor_and_event_resolution(df, sensor, event_resolution):
     """Set the Sensor metadata (including timing properties of the sensor)."""
+    
+
+    if not isinstance(sensor, Sensor):
+        import warnings
+
+        warnings.warn(
+            "'sensor' field needs to be of type 'Sensor'. This constraint will be enforced in an upcoming version.",
+            FutureWarning,
+        )
+
+        # TODO: raise ValueError(...)
+
     df.sensor = sensor
     df.event_resolution = (
         event_resolution

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -2192,7 +2192,6 @@ def set_columns_and_indices_for_empty_frame(df, columns, indices, default_types)
 
 def assign_sensor_and_event_resolution(df, sensor, event_resolution):
     """Set the Sensor metadata (including timing properties of the sensor)."""
-    
 
     if not isinstance(sensor, Sensor):
         import warnings


### PR DESCRIPTION
This PR introduces a warning message when the sensor attribute is not of type `Sensor`. In an upcoming version, we should raise a `ValueError` exception.


Closes https://github.com/SeitaBV/timely-beliefs/issues/140