### PR TITLE
Fix: resampling empty frames in read_csv

### DIFF
--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -807,6 +807,8 @@ def interpret_special_read_cases(
 
 
 def resample_events(df: pd.DataFrame, sensor: "classes.Sensor") -> pd.DataFrame:
+    if df.empty:
+        return df
     df = df.set_index("event_start")
     if df.index.freq is None and len(df) > 2:
         # Try to infer the event resolution from the event frequency


### PR DESCRIPTION
The read-in frame may have been emptied after filtering by some event time window (since #154).

Fix: empty frames have no discernible frequency, so resampling then fails. Fortunately, such frames also do not require resampling, so we can skip the resampling step altogether.