### PR TITLE
Fix/read csv with upsampling

### DIFF
--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -1767,7 +1767,6 @@ class BeliefsDataFrame(pd.DataFrame):
 
         df = self
         if t is None:
-
             # Set reference values if needed
             if (
                 reference_belief_horizon is not None

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -24,7 +24,6 @@ import numpy as np
 import pandas as pd
 import pytz
 from pandas.core.groupby import DataFrameGroupBy
-from pandas.tseries.frequencies import to_offset
 from pandas.util._decorators import cache_readonly
 from sqlalchemy import (
     Column,
@@ -1561,56 +1560,9 @@ class BeliefsDataFrame(pd.DataFrame):
                 df = df.reset_index(
                     level=[belief_timing_col, "source", "cumulative_probability"]
                 )
-                resample_ratio = pd.to_timedelta(
-                    to_offset(df.event_resolution)
-                ) / pd.Timedelta(event_resolution)
-                if keep_nan_values:
-                    # back up NaN values
-                    unique_event_value_not_in_df = df["event_value"].abs().sum() + 1
-                    df = df.fillna(unique_event_value_not_in_df)
-                new_index = belief_utils.initialize_index(
-                    start=df.index[0],
-                    end=df.index[-1] + self.event_resolution,
-                    resolution=event_resolution,
+                df = belief_utils.upsample_beliefs_data_frame(
+                    df, event_resolution, keep_nan_values
                 )
-                # Reindex to introduce NaN values, then forward fill by the number of steps
-                # needed to have the new resolution cover the old resolution.
-                # For example, when resampling from a resolution of 30 to 20 minutes (NB frequency is 1 hour):
-                # event_start               event_value
-                # 2020-03-29 10:00:00+02:00 1000.0
-                # 2020-03-29 11:00:00+02:00 NaN
-                # 2020-03-29 12:00:00+02:00 2000.0
-                # After reindexing
-                # event_start               event_value
-                # 2020-03-29 10:00:00+02:00 1000.0
-                # 2020-03-29 10:20:00+02:00 NaN
-                # 2020-03-29 10:40:00+02:00 NaN
-                # 2020-03-29 11:00:00+02:00 NaN
-                # 2020-03-29 11:20:00+02:00 NaN
-                # 2020-03-29 11:40:00+02:00 NaN
-                # 2020-03-29 12:00:00+02:00 2000.0
-                # 2020-03-29 12:20:00+02:00 NaN
-                # 2020-03-29 12:40:00+02:00 NaN
-                # After filling a limited number of NaN values (ceil(30/20)-1 == 1)
-                # event_start               event_value
-                # 2020-03-29 10:00:00+02:00 1000.0
-                # 2020-03-29 10:20:00+02:00 1000.0
-                # 2020-03-29 10:40:00+02:00 NaN
-                # 2020-03-29 11:00:00+02:00 NaN
-                # 2020-03-29 11:20:00+02:00 NaN
-                # 2020-03-29 11:40:00+02:00 NaN
-                # 2020-03-29 12:00:00+02:00 2000.0
-                # 2020-03-29 12:20:00+02:00 2000.0
-                # 2020-03-29 12:40:00+02:00 NaN
-                df = df.reindex(new_index).fillna(
-                    method="pad",
-                    limit=math.ceil(resample_ratio) - 1 if resample_ratio > 1 else None,
-                )
-                df = df.dropna()
-                if keep_nan_values:
-                    # place back original NaN values
-                    df = df.replace(unique_event_value_not_in_df, np.NaN)
-                df.event_resolution = event_resolution
                 df = df.set_index(
                     [belief_timing_col, "source", "cumulative_probability"], append=True
                 )

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -809,7 +809,9 @@ def interpret_special_read_cases(
     return df
 
 
-def resample_events(df: pd.DataFrame, sensor: "classes.Sensor", keep_nan_values=keep_nan_values) -> pd.DataFrame:
+def resample_events(
+    df: pd.DataFrame, sensor: "classes.Sensor", keep_nan_values=keep_nan_values
+) -> pd.DataFrame:
     if df.empty:
         return df
     df = df.set_index("event_start")
@@ -1039,7 +1041,9 @@ def meta_repr(
 
 
 def upsample_beliefs_data_frame(
-    df: "classes.BeliefsDataFrame" | pd.DataFrame, event_resolution: timedelta, keep_nan_values: bool = False
+    df: "classes.BeliefsDataFrame" | pd.DataFrame,
+    event_resolution: timedelta,
+    keep_nan_values: bool = False,
 ) -> "classes.BeliefsDataFrame":
     """Because simply doing df.resample().ffill() does not correctly resample the last event in the data frame.
 
@@ -1048,9 +1052,9 @@ def upsample_beliefs_data_frame(
     :param keep_nan_values:     If True, place back resampled NaN values. Drops NaN values by default.
     """
     from_event_resolution = df.event_resolution
-    resample_ratio = pd.to_timedelta(
-        to_offset(from_event_resolution)
-    ) / pd.Timedelta(event_resolution)
+    resample_ratio = pd.to_timedelta(to_offset(from_event_resolution)) / pd.Timedelta(
+        event_resolution
+    )
     if keep_nan_values:
         # back up NaN values
         unique_event_value_not_in_df = df["event_value"].abs().sum() + 1

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -1078,7 +1078,12 @@ def upsample_beliefs_data_frame(
         event_resolution
     )
     if keep_nan_values:
-        # back up NaN values
+        # Back up NaN values.
+        # We are flagging the positions of the NaN values in the original data with a unique number.
+        # The unique number is the series' L1 norm + 1, which is guaranteed not to exist within the series.
+        # For example, for x = [-2, 2, 0, 1, 0.5]  =>  y = L1 norm + 1 = 5.5 + 1 = 6.5
+        # The ( + 1 ) is needed for the special case of a series with only a single non-zero value.
+        # For example, for x = [0, 2, 0, 0, 0]  =>  y = L1 norm + 1 = 2 + 1 = 3
         unique_event_value_not_in_df = df["event_value"].abs().sum() + 1
         df = df.fillna(unique_event_value_not_in_df)
     if isinstance(df, classes.BeliefsDataFrame):

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -1071,8 +1071,9 @@ def upsample_beliefs_data_frame(
         return df
     if event_resolution == timedelta(0):
         raise NotImplementedError("Cannot upsample to zero event resolution.")
-
     from_event_resolution = df.event_resolution
+    if from_event_resolution == timedelta(0):
+        raise NotImplementedError("Cannot upsample from zero event resolution.")
     resample_ratio = pd.to_timedelta(to_offset(from_event_resolution)) / pd.Timedelta(
         event_resolution
     )

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -810,7 +810,7 @@ def interpret_special_read_cases(
 
 
 def resample_events(
-    df: pd.DataFrame, sensor: "classes.Sensor", keep_nan_values=keep_nan_values
+    df: pd.DataFrame, sensor: "classes.Sensor", keep_nan_values: bool
 ) -> pd.DataFrame:
     if df.empty:
         return df

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -1066,6 +1066,10 @@ def upsample_beliefs_data_frame(
     :param event_resolution:    Resolution to upsample to.
     :param keep_nan_values:     If True, place back resampled NaN values. Drops NaN values by default.
     """
+    if df.empty:
+        df.event_resolution = event_resolution
+        return df
+
     from_event_resolution = df.event_resolution
     resample_ratio = pd.to_timedelta(to_offset(from_event_resolution)) / pd.Timedelta(
         event_resolution

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -1069,6 +1069,8 @@ def upsample_beliefs_data_frame(
     if df.empty:
         df.event_resolution = event_resolution
         return df
+    if event_resolution == timedelta(0):
+        raise NotImplementedError("Cannot upsample to zero event resolution.")
 
     from_event_resolution = df.event_resolution
     resample_ratio = pd.to_timedelta(to_offset(from_event_resolution)) / pd.Timedelta(

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -65,7 +65,7 @@ def upsample_event_start(
     df,
     output_resolution: timedelta,
     input_resolution: timedelta,
-    fill_method: Optional[str] = "pad",
+    fill_method: Optional[str] = "ffill",
 ):
     """Upsample event_start (which must be the first index level) from input_resolution to output_resolution."""
 
@@ -97,10 +97,10 @@ def upsample_event_start(
     # Todo: allow customisation for de-aggregating event values
     if fill_method is None:
         return df.reindex(mux)
-    elif fill_method == "pad":
+    elif fill_method == "ffill":
         return df.reindex(mux).fillna(
-            method="pad"
-        )  # pad is the reverse of mean downsampling
+            method="ffill"
+        )  # ffill (formerly 'pad') is the reverse of mean downsampling
     else:
         raise NotImplementedError("Unknown upsample method.")
 
@@ -1126,7 +1126,7 @@ def upsample_beliefs_data_frame(
         df = df.reset_index().set_index("event_start")
     df = df.reindex(new_index)
     df = df.fillna(
-        method="pad",
+        method="ffill",
         limit=math.ceil(resample_ratio) - 1 if resample_ratio > 1 else None,
     )
     df = df.dropna()


### PR DESCRIPTION
Refactoring just to reuse existing upsampling functionality (for forward filling) in `read_csv`. Because simply doing `df.resample().ffill()` does not correctly resample the last event in the data frame.