### PR TITLE
Support SQLAlchemy 2.0.x

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -54,7 +54,7 @@ six==1.15.0
     #   isodate
     #   jsonschema
     #   python-dateutil
-sqlalchemy==1.3.19
+sqlalchemy==2.0.0
     # via timely-beliefs (setup.py)
 toolz==0.10.0
     # via altair

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 
     # Database support
     "psycopg2-binary",
-    "SQLAlchemy",
+    "SQLAlchemy>=2",
 
     # Conditional
     # numpy's setup requires minimal Python versions

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -39,7 +39,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
-from sqlalchemy.orm import Session, backref, relationship, has_inherited_table
+from sqlalchemy.orm import Session, backref, has_inherited_table, relationship
 from sqlalchemy.orm.util import AliasedClass
 from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.sql.elements import BinaryExpression
@@ -453,13 +453,9 @@ class TimedBeliefDBMixin(TimedBelief):
                 raise ValueError(
                     f"sensor {sensor} is a {type(sensor)}, which is not a subclass of {SensorDBMixin}"
                 )
-            sensor = (
-                session.execute(
-                    select(sensor_class)
-                    .filter(sensor_class.id == sensor)
-                )
-                .scalar_one_or_none()
-            )
+            sensor = session.execute(
+                select(sensor_class).filter(sensor_class.id == sensor)
+            ).scalar_one_or_none()
             if sensor is None:
                 raise ValueError("No such sensor")
 

--- a/timely_beliefs/beliefs/queries.py
+++ b/timely_beliefs/beliefs/queries.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Optional
 
-from sqlalchemy import and_, func
+from sqlalchemy import and_, func, select, Select
 from sqlalchemy.orm import Query, Session, aliased
 
 
@@ -11,7 +11,7 @@ def query_unchanged_beliefs(
     query: Optional[Query] = None,
     include_positive_horizons: bool = True,  # include belief horizons > 0 (i.e. forecasts)
     include_non_positive_horizons: bool = True,  # include belief horizons <= 0 (i.e. measurements, nowcasts and backcasts)
-) -> Query:
+) -> Select:
     """Match unchanged beliefs.
 
     Unchanged beliefs are beliefs that have not changed with respect to the preceding belief,
@@ -21,7 +21,7 @@ def query_unchanged_beliefs(
         # Avoid circular import
         from timely_beliefs import DBTimedBelief as cls
     if query is None:
-        query = session.query(cls)
+        query = select(cls)
 
     # Set up aliases
     tb1 = cls  # the DBTimedBelief class mapped to the timed_beliefs table

--- a/timely_beliefs/beliefs/queries.py
+++ b/timely_beliefs/beliefs/queries.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Optional
 
-from sqlalchemy import and_, func, select, Select
+from sqlalchemy import Select, and_, func, select
 from sqlalchemy.orm import Query, Session, aliased
 
 

--- a/timely_beliefs/db_base.py
+++ b/timely_beliefs/db_base.py
@@ -1,3 +1,3 @@
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()

--- a/timely_beliefs/tests/__init__.py
+++ b/timely_beliefs/tests/__init__.py
@@ -1,6 +1,6 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-engine = create_engine("postgresql://flexmeasures_test:flexmeasures_test@127.0.0.1/flexmeasures_test")
+engine = create_engine("postgresql://tbtest:tbtest@127.0.0.1/tbtest")
 Session = sessionmaker(bind=engine)
 session = Session()

--- a/timely_beliefs/tests/__init__.py
+++ b/timely_beliefs/tests/__init__.py
@@ -1,6 +1,6 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-engine = create_engine("postgresql://tbtest:tbtest@127.0.0.1/tbtest")
+engine = create_engine("postgresql://flexmeasures_test:flexmeasures_test@127.0.0.1/flexmeasures_test")
 Session = sessionmaker(bind=engine)
 session = Session()

--- a/timely_beliefs/tests/test_sensor_query.py
+++ b/timely_beliefs/tests/test_sensor_query.py
@@ -1,6 +1,8 @@
+from sqlalchemy import select
+
 from timely_beliefs import DBSensor
 from timely_beliefs.tests import session
 
 
 def test_persist_sensor(db):
-    assert session.query(DBSensor).first()
+    assert session.scalar(select(DBSensor).limit(1))


### PR DESCRIPTION

In this pull request, I've advanced the SQLAlchemy version from `1.3.19` to `2.0.0` and adjusted the queries to adhere to the `2.0.x` format. I have used pytest to test all the new changes.


## References:
- 1.x->2.x [Migration Guide](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html)
- SQLAlchemy Blog [post](https://www.sqlalchemy.org/blog/2023/01/26/sqlalchemy-2.0.0-released/)