### PR TITLE
Fix/add event filters to search subquery

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,10 +10,8 @@ repos:
         hooks:
               - id: flake8
                 name: flake8 (code linting)
-                language_version: python3.9
       - repo: https://github.com/psf/black
         rev: 22.12.0  # New version tags can be found here: https://github.com/psf/black/tags
         hooks:
               - id: black
                 name: black (code formatting)
-                language_version: python3.9

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -508,7 +508,6 @@ class TimedBeliefDBMixin(TimedBelief):
                 .group_by(cls.event_start, cls.source_id)
                 .subquery()
             )
-            print(str(subq))
             q = q.join(
                 subq,
                 and_(

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -412,7 +412,7 @@ class TimedBeliefDBMixin(TimedBelief):
                 else:
                     # exclusive
                     q = q.filter(
-                        cls.event_start + sensor.event_resolution > event_ends_after
+                        cls.event_start > event_ends_after - sensor.event_resolution
                     )
             if not pd.isnull(event_starts_before):
                 if sensor.event_resolution == timedelta(0):
@@ -423,7 +423,7 @@ class TimedBeliefDBMixin(TimedBelief):
                     q = q.filter(cls.event_start < event_starts_before)
             if not pd.isnull(event_ends_before):
                 q = q.filter(
-                    cls.event_start + sensor.event_resolution <= event_ends_before
+                    cls.event_start <= event_ends_before - sensor.event_resolution
                 )
 
             return q
@@ -441,8 +441,8 @@ class TimedBeliefDBMixin(TimedBelief):
                 knowledge_horizon_min, timedelta.min
             ):
                 q = q.filter(
-                    cls.event_start
-                    >= beliefs_after + cls.belief_horizon + knowledge_horizon_min
+                    cls.event_start - cls.belief_horizon
+                    >= beliefs_after + knowledge_horizon_min
                 )
             if not pd.isnull(
                 beliefs_before
@@ -450,8 +450,8 @@ class TimedBeliefDBMixin(TimedBelief):
                 knowledge_horizon_max, timedelta.max
             ):
                 q = q.filter(
-                    cls.event_start
-                    <= beliefs_before + cls.belief_horizon + knowledge_horizon_max
+                    cls.event_start - cls.belief_horizon
+                    <= beliefs_before + knowledge_horizon_max
                 )
 
             # Apply belief horizon filter

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -501,7 +501,7 @@ class TimedBeliefDBMixin(TimedBelief):
             )
             # Apply event and belief timing filters to the subquery, too,
             # before taking the minimum horizon (the former is crucial for speed)
-            # subq = apply_event_timing_filters(subq)
+            subq = apply_event_timing_filters(subq)
             subq = apply_belief_timing_filters(subq)
             subq = (
                 subq.filter(cls.sensor_id == sensor.id)


### PR DESCRIPTION
Querying timely beliefs data from the database takes way longer than it should.

Digging in, we found that a subquery for selecting only the latest belief was missing some `event_start` filtering. This meant that the subquer  was applied to all data, probably multiple times over, when it suffices to only check the same data subset that the main query is interested in.

Next to improving the where criteria for the subquery, we also looked into adding another index, see #167.

The event start filtering can improve the query time by a factor of around 4 (if the sensor has sufficient data, that's the time-scaling factor).

This is the query as it is happening before this PR:

```
SELECT timed_belief.event_start, timed_belief.belief_horizon, timed_belief.source_id, timed_belief.cumulative_probability, timed_belief.event_value 
FROM timed_belief
JOIN data_source ON data_source.id = timed_belief.source_id
JOIN (SELECT timed_belief.event_start AS event_start, timed_belief.source_id AS source_id,  
           min(timed_belief.belief_horizon) AS most_recent_belief_horizon 
           FROM timed_belief
           JOIN data_source ON data_source.id = timed_belief.source_id 
           WHERE timed_belief.sensor_id = :sensor_id_1 GROUP BY timed_belief.event_start, timed_belief.source_id
          ) AS anon_1
ON timed_belief.event_start = anon_1.event_start AND timed_belief.source_id = anon_1.source_id
AND timed_belief.belief_horizon = anon_1.most_recent_belief_horizon 
WHERE timed_belief.sensor_id = :sensor_id_2 AND timed_belief.event_start + :event_start_1 > :param_1
AND timed_belief.event_start < :event_start_2
```
(the naming of the parameters is confusing - `event_start_1` is an horizon, I believe, and `param_1` a datetime)

The subquery `anon_1` is not applying the `event_start` time window so we'll add `timed_belief.event_start + :event_start_1 > :param_1 AND timed_belief.event_start < :event_start_2` to its where clause, as well.

Here is the code I used for timing (could be rewritten to only work in timely-beliefs) within `flexmeasures shell`:

```
from flexmeasures.data.models.time_series import TimedBelief

from datetime import datetime, timedelta
import pytz
import timeit
sensor=5
from_time = datetime(2023, 8, 10, tzinfo=pytz.UTC)
to_time = from_time + timedelta(days=2)
start_time = datetime.now()
TimedBelief.search(sensors=[sensor], event_starts_after=from_time, event_ends_before=to_time)
time=datetime.now()-start_time; print(f"This took: {time.seconds}.{time.microseconds} seconds.")
print("----")

```