### PR TITLE
fix: apply event timing and belief timing filters to subquery to find the most recent event

### DIFF
--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -520,12 +520,18 @@ class TimedBeliefDBMixin(TimedBelief):
 
         # Apply most recent events filter as subquery
         if most_recent_events_only:
+            subq_most_recent_events = select(
+                cls.source_id,
+                func.max(cls.event_start).label("most_recent_event_start"),
+            )
+            subq_most_recent_events = apply_event_timing_filters(
+                subq_most_recent_events
+            )
+            subq_most_recent_events = apply_belief_timing_filters(
+                subq_most_recent_events
+            )
             subq_most_recent_events = (
-                select(
-                    cls.source_id,
-                    func.max(cls.event_start).label("most_recent_event_start"),
-                )
-                .filter(cls.sensor_id == sensor.id)
+                subq_most_recent_events.filter(cls.sensor_id == sensor.id)
                 .group_by(cls.source_id)
                 .subquery()
             )


### PR DESCRIPTION
- Resolves an issue described in https://github.com/FlexMeasures/flexmeasures/pull/941#issuecomment-1927341440
- Also led to an issue with resetting starting SoC values in flexmeasures-simulate when dividing a long simulation into smaller chunks.
- Related: https://github.com/SeitaBV/timely-beliefs/issues/97