### PR TITLE
add `at_date_annually` knowledge horizon function

### DIFF
--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -65,8 +65,8 @@ def x_years_ago_at_date(
     if get_bounds:
         # The minimum corresponds to an event at the 1st of January and a publication date on the 31st of December on the year `x` years ago.
         # The maximum corresponds to an event just before new year's midnight and a publication date on the 1st of January on the year `x` years ago.
-        return timedelta(days=(x - 1) * MIN_DAYS_IN_A_YEAR), timedelta(
-            days=(x + 1) * MAX_DAYS_IN_A_YEAR + 1
+        return timedelta(days=(x - 1) * MIN_DAYS_IN_A_YEAR + 1), timedelta(
+            days=(x + 1) * MAX_DAYS_IN_A_YEAR
         )
 
     if isinstance(event_start, datetime):

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -37,21 +37,21 @@ def at_date(
 
 def x_years_ago_at_date(
     event_start: datetime | pd.DatetimeIndex,
+    x: int,
     day: int,
     month: int,
-    x: int = 1,
+    z: str,
     get_bounds: bool = False,
-    z: str | None = None,
 ) -> timedelta | pd.TimedeltaIndex | tuple[timedelta, timedelta]:
     """Compute the sensor's knowledge horizon to represent the event could be known since some date, `x` years ago.
 
     For example, it can be used for a tax rate that changes annually and with a known publication date.
 
     :param event_start:     Start of the event, used as an anchor for determining the knowledge horizon.
+    :param x:               The number of years to shift the reference date to.
     :param day:             Reference day of the month of the annual date to compare against.
     :param month:           The month of the annual date to compare against.
-    :param x:               The number of years to shift the reference date to.
-    :param z:           Timezone string.
+    :param z:               Timezone string.
     :param get_bounds:      If True, this function returns bounds on the possible return value.
                             These bounds are normally useful for creating more efficient database queries when filtering by belief time.
     """
@@ -69,7 +69,7 @@ def x_years_ago_at_date(
             days=(x + 1) * MAX_DAYS_IN_A_YEAR
         )
 
-    return event_start - datetime_x_years_ago_at_date(event_start, day, month, x, z)
+    return event_start - datetime_x_years_ago_at_date(event_start, x, day, month, z)
 
 
 def ex_post(

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -54,8 +54,12 @@ def x_years_ago_at_date(
     :param get_bounds:      If True, this function returns bounds on the possible return value.
                             These bounds are normally useful for creating more efficient database queries when filtering by belief time.
     """
+
+    if x >= 0:
+        raise ValueError("Negative value for `x` not supported.")
+
     if get_bounds:
-        return timedelta.min, timedelta.days(366 * x)
+        return timedelta(days=(x-1)*366 - 3), timedelta(days=(x+1)*366 +1)
 
     if isinstance(event_start, datetime):
         return x_years_ago_at_date_datetime(event_start, day, month, x, z)

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -1,6 +1,7 @@
 """Function store for computing knowledge horizons given a certain event start and resolution.
 When passed get_bounds=True, these functions return bounds on the knowledge horizon,
 i.e. a duration window in which the knowledge horizon must lie (e.g. between 0 and 2 days before the event start)."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta
@@ -62,9 +63,11 @@ def x_years_ago_at_date(
         raise ValueError("Only positive values for `x` are supported.")
 
     if get_bounds:
-        # The minimum corresponds to an event at the 1st of January and a reference on the 31st of December on the the year `x` years ago.
-        # The maximum correponds to an event on the 31st of December and a reference on the 1st of January on the year `x` years ago.
-        return timedelta(days=(x - 1) * MIN_DAYS_IN_A_YEAR), timedelta(days=(x + 1) * MAX_DAYS_IN_A_YEAR + 1)
+        # The minimum corresponds to an event at the 1st of January and a publication date on the 31st of December on the year `x` years ago.
+        # The maximum corresponds to an event just before new year's midnight and a publication date on the 1st of January on the year `x` years ago.
+        return timedelta(days=(x - 1) * MIN_DAYS_IN_A_YEAR), timedelta(
+            days=(x + 1) * MAX_DAYS_IN_A_YEAR + 1
+        )
 
     if isinstance(event_start, datetime):
         return x_years_ago_at_date_datetime(event_start, day, month, x, z)

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -7,9 +7,8 @@ from datetime import datetime, timedelta
 
 import pandas as pd
 
-from timely_beliefs.sensors.func_store.utils import datetime_x_days_ago_at_y_oclock
+from timely_beliefs.sensors.func_store.utils import datetime_x_days_ago_at_y_oclock, x_years_ago_at_date_datetime
 
-from pytz import timezone
 
 def at_date(
     event_start: datetime | pd.DatetimeIndex | None,
@@ -52,19 +51,9 @@ def x_years_ago_at_date(
     :param z:           Timezone string.
     :param get_bounds:      If True, this function returns bounds on the possible return value.
                             These bounds are normally useful for creating more efficient database queries when filtering by belief time.
-                            In this case, the knowledge horizon is unbounded.
     """
     if get_bounds:
-        return timedelta.min, timedelta.max
-    def x_years_ago_at_date_datetime(_event_start : datetime, day : int, month : int, x : int, z : str | None) -> timedelta:
-        if z is None:
-            z = _event_start.tzinfo
-        else:
-            z = timezone(z)
-
-        anchor = dict(year=_event_start.year - x, month=month, day=day, hour=0, minute=0, second=0, microsecond=0, tzinfo=z)
-
-        return _event_start - _event_start.replace(**anchor)
+        return timedelta.min, timedelta.days(366 * x)
         
     if isinstance(event_start, datetime):
         return x_years_ago_at_date_datetime(event_start, day, month, x, z)

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -7,7 +7,10 @@ from datetime import datetime, timedelta
 
 import pandas as pd
 
-from timely_beliefs.sensors.func_store.utils import datetime_x_days_ago_at_y_oclock, x_years_ago_at_date_datetime
+from timely_beliefs.sensors.func_store.utils import (
+    datetime_x_days_ago_at_y_oclock,
+    x_years_ago_at_date_datetime,
+)
 
 
 def at_date(
@@ -31,18 +34,17 @@ def at_date(
     return event_start - knowledge_time.astimezone(event_start.tzinfo)
 
 
-
 def x_years_ago_at_date(
     event_start: datetime | pd.DatetimeIndex,
     day: int,
-    month : int,
-    x : int = 1,
+    month: int,
+    x: int = 1,
     get_bounds: bool = False,
     z: str | None = None,
 ) -> timedelta | pd.TimedeltaIndex | tuple[timedelta, timedelta]:
     """Compute the sensor's knowledge horizon to represent the event could be known since some date, `x` years ago.
-    
-    For example, it can be used for a tax rate that changes annually and with a known publication date. 
+
+    For example, it can be used for a tax rate that changes annually and with a known publication date.
 
     :param event_start:     Start of the event, used as an anchor for determining the knowledge horizon.
     :param day:             Reference day of the month of the annual date to compare against.
@@ -54,11 +56,16 @@ def x_years_ago_at_date(
     """
     if get_bounds:
         return timedelta.min, timedelta.days(366 * x)
-        
+
     if isinstance(event_start, datetime):
         return x_years_ago_at_date_datetime(event_start, day, month, x, z)
     else:
-        return event_start.map(lambda _event_start: x_years_ago_at_date_datetime(_event_start,day,month, x, z))
+        return event_start.map(
+            lambda _event_start: x_years_ago_at_date_datetime(
+                _event_start, day, month, x, z
+            )
+        )
+
 
 def ex_post(
     event_resolution: timedelta,

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -31,6 +31,46 @@ def at_date(
     return event_start - knowledge_time.astimezone(event_start.tzinfo)
 
 
+
+def at_date_annually(
+    event_start: datetime | pd.DatetimeIndex,
+    day: int,
+    month : int,
+    get_bounds: bool = False,
+) -> timedelta | pd.TimedeltaIndex | tuple[timedelta, timedelta]:
+    """Compute the sensor's knowledge horizon to represent the event could be known since some fixed date on the same year as the event_start.
+    
+    Note: if the event_start happens before the day and month, the knowledge time will be based on the previous year reference.
+
+    For example, it can be used for a tax rate that changes annually and with a known publication date.
+
+    :param event_start:     Start of the event, used as an anchor for determining the knowledge horizon.
+    :param day:             Reference day of the month of the annual date to compare against.
+    :param month:           The month of the annual date to compare against.
+    :param get_bounds:      If True, this function returns bounds on the possible return value.
+                            These bounds are normally useful for creating more efficient database queries when filtering by belief time.
+                            In this case, the knowledge horizon is unbounded.
+    """
+    if get_bounds:
+        return timedelta.min, timedelta.max
+
+    def at_date_annually_datetime(_event_start : datetime, day : int, month : int) -> timedelta:
+        current_year_anchor = dict(year=_event_start.year, month=month, day=day, hour=0, minute=0, second=0, microsecond=0)
+        previous_year_anchor = dict(year=_event_start.year-1, month=month, day=day, hour=0, minute=0, second=0, microsecond=0)
+
+        delta_this_year  =  _event_start - _event_start.replace(**current_year_anchor)
+        delta_previous_year  =  _event_start - _event_start.replace(**previous_year_anchor)
+
+        if delta_this_year > timedelta(0):
+            return delta_this_year
+        else:
+            return delta_previous_year
+        
+    if isinstance(event_start, datetime):
+        return at_date_annually_datetime(event_start, day, month)
+    else:
+        return event_start.map(lambda _event_start: at_date_annually_datetime(_event_start,day,month))
+
 def ex_post(
     event_resolution: timedelta,
     ex_post_horizon: timedelta,

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -55,7 +55,7 @@ def x_years_ago_at_date(
                             These bounds are normally useful for creating more efficient database queries when filtering by belief time.
     """
 
-    if x >= 0:
+    if x < 0:
         raise ValueError("Negative value for `x` not supported.")
 
     if get_bounds:

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -72,7 +72,9 @@ def x_years_ago_at_date(
     if isinstance(event_start, datetime):
         return x_years_ago_at_date_datetime(event_start, day, month, x, z)
     else:
-        ref = event_start.to_period("1Y").to_timestamp().tz_localize(event_start.tz) + pd.DateOffset(month=month, day=day, years=-x)
+        ref = event_start.to_period("1Y").to_timestamp().tz_localize(
+            event_start.tz
+        ) + pd.DateOffset(month=month, day=day, years=-x)
         return event_start - ref
 
 

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -56,7 +56,7 @@ def x_years_ago_at_date(
     """
 
     MAX_DAYS_IN_A_YEAR = 366
-    MIN_DAYS_IN_A_YEAR = 366
+    MIN_DAYS_IN_A_YEAR = 364
 
     if x <= 0:
         raise ValueError("Only positive values for `x` are supported.")

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -55,11 +55,16 @@ def x_years_ago_at_date(
                             These bounds are normally useful for creating more efficient database queries when filtering by belief time.
     """
 
-    if x < 0:
-        raise ValueError("Negative value for `x` not supported.")
+    MAX_DAYS_IN_A_YEAR = 366
+    MIN_DAYS_IN_A_YEAR = 366
+
+    if x <= 0:
+        raise ValueError("Only positive values for `x` are supported.")
 
     if get_bounds:
-        return timedelta(days=(x - 1) * 366 - 3), timedelta(days=(x + 1) * 366 + 1)
+        # The minimum corresponds to an event at the 1st of January and a reference on the 31st of December on the the year `x` years ago.
+        # The maximum correponds to an event on the 31st of December and a reference on the 1st of January on the year `x` years ago.
+        return timedelta(days=(x - 1) * MIN_DAYS_IN_A_YEAR), timedelta(days=(x + 1) * MAX_DAYS_IN_A_YEAR + 1)
 
     if isinstance(event_start, datetime):
         return x_years_ago_at_date_datetime(event_start, day, month, x, z)

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -59,7 +59,7 @@ def x_years_ago_at_date(
         raise ValueError("Negative value for `x` not supported.")
 
     if get_bounds:
-        return timedelta(days=(x-1)*366 - 3), timedelta(days=(x+1)*366 +1)
+        return timedelta(days=(x - 1) * 366 - 3), timedelta(days=(x + 1) * 366 + 1)
 
     if isinstance(event_start, datetime):
         return x_years_ago_at_date_datetime(event_start, day, month, x, z)

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from timely_beliefs.sensors.func_store.utils import (
     datetime_x_days_ago_at_y_oclock,
-    x_years_ago_at_date_datetime,
+    datetime_x_years_ago_at_date,
 )
 
 
@@ -69,13 +69,7 @@ def x_years_ago_at_date(
             days=(x + 1) * MAX_DAYS_IN_A_YEAR
         )
 
-    if isinstance(event_start, datetime):
-        return x_years_ago_at_date_datetime(event_start, day, month, x, z)
-    else:
-        ref = event_start.to_period("1Y").to_timestamp().tz_localize(
-            event_start.tz
-        ) + pd.DateOffset(month=month, day=day, years=-x)
-        return event_start - ref
+    return event_start - datetime_x_years_ago_at_date(event_start, day, month, x, z)
 
 
 def ex_post(

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -69,11 +69,8 @@ def x_years_ago_at_date(
     if isinstance(event_start, datetime):
         return x_years_ago_at_date_datetime(event_start, day, month, x, z)
     else:
-        return event_start.map(
-            lambda _event_start: x_years_ago_at_date_datetime(
-                _event_start, day, month, x, z
-            )
-        )
+        ref = event_start.to_period("1Y").to_timestamp().tz_localize(event_start.tz) + pd.DateOffset(month=month, day=day)
+        return event_start - ref
 
 
 def ex_post(

--- a/timely_beliefs/sensors/func_store/knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/knowledge_horizons.py
@@ -56,7 +56,7 @@ def x_years_ago_at_date(
     """
 
     MAX_DAYS_IN_A_YEAR = 366
-    MIN_DAYS_IN_A_YEAR = 364
+    MIN_DAYS_IN_A_YEAR = 365
 
     if x <= 0:
         raise ValueError("Only positive values for `x` are supported.")
@@ -69,7 +69,7 @@ def x_years_ago_at_date(
     if isinstance(event_start, datetime):
         return x_years_ago_at_date_datetime(event_start, day, month, x, z)
     else:
-        ref = event_start.to_period("1Y").to_timestamp().tz_localize(event_start.tz) + pd.DateOffset(month=month, day=day)
+        ref = event_start.to_period("1Y").to_timestamp().tz_localize(event_start.tz) + pd.DateOffset(month=month, day=day, years=-x)
         return event_start - ref
 
 

--- a/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
@@ -1,3 +1,5 @@
+import pytest
+
 from datetime import datetime, timedelta
 
 import pandas as pd
@@ -141,6 +143,25 @@ def test_x_years_ago_at_date():
     ) == timedelta(
         days=2 * 365, hours=1
     )  # 365 days + 366 days - 1 day
+
+
+
+@pytest.mark.parametrize("event_start", [
+    datetime(2024, 1, 1, 0, tzinfo=utc),
+    datetime(2024, 12, 31, 23, 59, 59, tzinfo=utc)
+])
+@pytest.mark.parametrize("year", list(range(6)))
+def test_x_years_ago_at_date_bounds(event_start, year):
+    knowledge_func_params = dict(month=12, day=31, x=year)
+
+    timedelta_bounds = x_years_ago_at_date(event_start, get_bounds=True, **knowledge_func_params)
+
+    assert (
+        timedelta_bounds[0]
+        < x_years_ago_at_date(event_start, **knowledge_func_params)
+        < timedelta_bounds[1]
+    )
+
 
 
 def test_dst():

--- a/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
@@ -73,7 +73,7 @@ def test_x_years_ago_at_date():
         **knowledge_func_params
     ) == timedelta(days=364, hours=2) # 365 - 1
 
-    # year 2023 is not leap and 2022 either
+    # year 2023 is not leap and 2022 neither
     assert x_years_ago_at_date(
         event_start=datetime(2022, 11, 19, 2, tzinfo=utc),
         **knowledge_func_params
@@ -118,7 +118,7 @@ def test_x_years_ago_at_date():
     assert x_years_ago_at_date(
         event_start=datetime(2024, 11, 19, 1, tzinfo=utc),
         **knowledge_func_params_2_years
-    ) == timedelta(days=2*365, hours=1) # 366 days - 1
+    ) == timedelta(days=2*365, hours=1) # 365 days + 366 days - 1 day
 
 
 def test_dst():

--- a/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
@@ -162,8 +162,8 @@ def test_x_years_ago_at_date_bounds(event_start, years):
 
     assert (
         timedelta_bounds[0]
-        < x_years_ago_at_date(event_start, **knowledge_func_params)
-        < timedelta_bounds[1]
+        <= x_years_ago_at_date(event_start, **knowledge_func_params)
+        <= timedelta_bounds[1]
     )
 
 

--- a/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
@@ -152,7 +152,7 @@ def test_x_years_ago_at_date():
         datetime(2024, 12, 31, 23, 59, 59, tzinfo=utc),
     ],
 )
-@pytest.mark.parametrize("year", list(range(1,6)))
+@pytest.mark.parametrize("year", list(range(1, 6)))
 def test_x_years_ago_at_date_bounds(event_start, year):
     knowledge_func_params = dict(month=12, day=31, x=year)
 

--- a/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
@@ -145,23 +145,26 @@ def test_x_years_ago_at_date():
     )  # 365 days + 366 days - 1 day
 
 
-
-@pytest.mark.parametrize("event_start", [
-    datetime(2024, 1, 1, 0, tzinfo=utc),
-    datetime(2024, 12, 31, 23, 59, 59, tzinfo=utc)
-])
+@pytest.mark.parametrize(
+    "event_start",
+    [
+        datetime(2024, 1, 1, 0, tzinfo=utc),
+        datetime(2024, 12, 31, 23, 59, 59, tzinfo=utc),
+    ],
+)
 @pytest.mark.parametrize("year", list(range(6)))
 def test_x_years_ago_at_date_bounds(event_start, year):
     knowledge_func_params = dict(month=12, day=31, x=year)
 
-    timedelta_bounds = x_years_ago_at_date(event_start, get_bounds=True, **knowledge_func_params)
+    timedelta_bounds = x_years_ago_at_date(
+        event_start, get_bounds=True, **knowledge_func_params
+    )
 
     assert (
         timedelta_bounds[0]
         < x_years_ago_at_date(event_start, **knowledge_func_params)
         < timedelta_bounds[1]
     )
-
 
 
 def test_dst():

--- a/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
@@ -152,7 +152,7 @@ def test_x_years_ago_at_date():
         datetime(2024, 12, 31, 23, 59, 59, tzinfo=utc),
     ],
 )
-@pytest.mark.parametrize("year", list(range(6)))
+@pytest.mark.parametrize("year", list(range(1,6)))
 def test_x_years_ago_at_date_bounds(event_start, year):
     knowledge_func_params = dict(month=12, day=31, x=year)
 

--- a/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
@@ -1,17 +1,16 @@
-import pytest
-
 from datetime import datetime, timedelta
 
 import pandas as pd
+import pytest
 from pandas.testing import assert_index_equal
-from pytz import utc, timezone
+from pytz import timezone, utc
 
 from timely_beliefs.sensors.func_store.knowledge_horizons import (
     at_date,
-    x_years_ago_at_date,
     ex_ante,
     ex_post,
     x_days_ago_at_y_oclock,
+    x_years_ago_at_date,
 )
 
 

--- a/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
@@ -152,9 +152,9 @@ def test_x_years_ago_at_date():
         datetime(2024, 12, 31, 23, 59, 59, tzinfo=utc),
     ],
 )
-@pytest.mark.parametrize("year", list(range(1, 6)))
-def test_x_years_ago_at_date_bounds(event_start, year):
-    knowledge_func_params = dict(month=12, day=31, x=year)
+@pytest.mark.parametrize("years", list(range(1, 6)))
+def test_x_years_ago_at_date_bounds(event_start, years):
+    knowledge_func_params = dict(month=12, day=31, x=years)
 
     timedelta_bounds = x_years_ago_at_date(
         event_start, get_bounds=True, **knowledge_func_params

--- a/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
@@ -58,67 +58,89 @@ def test_fixed_knowledge_time():
 def test_x_years_ago_at_date():
     """Check definition of knowledge horizon for events known at a fixed date annually."""
 
-    knowledge_func_params = dict(month=11, day=20)    
-    
+    knowledge_func_params = dict(month=11, day=20)
+
     # Events that occur before the reference
     # year 2024 is leap
     assert x_years_ago_at_date(
-        event_start=datetime(2024, 11, 19, 1, tzinfo=utc),
-        **knowledge_func_params
-    ) == timedelta(days=365, hours=1) # 366 days - 1
+        event_start=datetime(2024, 11, 19, 1, tzinfo=utc), **knowledge_func_params
+    ) == timedelta(
+        days=365, hours=1
+    )  # 366 days - 1
 
     # year 2025 is not leap, but 2024 is
     assert x_years_ago_at_date(
-        event_start=datetime(2025, 11, 19, 2, tzinfo=utc),
-        **knowledge_func_params
-    ) == timedelta(days=364, hours=2) # 365 - 1
+        event_start=datetime(2025, 11, 19, 2, tzinfo=utc), **knowledge_func_params
+    ) == timedelta(
+        days=364, hours=2
+    )  # 365 - 1
 
     # year 2023 is not leap and 2022 neither
     assert x_years_ago_at_date(
-        event_start=datetime(2022, 11, 19, 2, tzinfo=utc),
-        **knowledge_func_params
-    ) == timedelta(days=364, hours=2) # 365 - 1
+        event_start=datetime(2022, 11, 19, 2, tzinfo=utc), **knowledge_func_params
+    ) == timedelta(
+        days=364, hours=2
+    )  # 365 - 1
 
     # Events that occur after the reference
     assert x_years_ago_at_date(
-        event_start=datetime(2021, 11, 21, 3, tzinfo=utc),
-        **knowledge_func_params
-    ) == timedelta(days=366, hours=3) # 365 + 1
+        event_start=datetime(2021, 11, 21, 3, tzinfo=utc), **knowledge_func_params
+    ) == timedelta(
+        days=366, hours=3
+    )  # 365 + 1
 
     assert x_years_ago_at_date(
-        event_start=datetime(2021, 11, 21, 4, tzinfo=utc),
-        **knowledge_func_params
-    ) == timedelta(days=366, hours=4) # 365 + 1
+        event_start=datetime(2021, 11, 21, 4, tzinfo=utc), **knowledge_func_params
+    ) == timedelta(
+        days=366, hours=4
+    )  # 365 + 1
 
     assert x_years_ago_at_date(
-        event_start=datetime(2020, 11, 21, 4, tzinfo=utc),
-        **knowledge_func_params
-    ) == timedelta(days=367, hours=4) # 366 (leap year) + 1
+        event_start=datetime(2020, 11, 21, 4, tzinfo=utc), **knowledge_func_params
+    ) == timedelta(
+        days=367, hours=4
+    )  # 366 (leap year) + 1
 
     # Test a Daylight Savings Transition
-    knowledge_func_params_dst = dict(month=3, day=23) # DST transition 2024
+    knowledge_func_params_dst = dict(month=3, day=23)  # DST transition 2024
     assert x_years_ago_at_date(
         event_start=datetime(2024, 3, 25, 0, tzinfo=timezone("Europe/Amsterdam")),
-        **knowledge_func_params_dst
+        **knowledge_func_params_dst,
     ) == timedelta(days=368)
 
     # Repeat test with pd.DatetimeIndex instead
-    event_start = pd.DatetimeIndex(["2024-11-19T01:00:00", "2025-11-19T02:00:00", "2022-11-19T02:00:00", "2021-11-21T03:00:00", "2021-11-21T04:00:00"], tz="utc")
+    event_start = pd.DatetimeIndex(
+        [
+            "2024-11-19T01:00:00",
+            "2025-11-19T02:00:00",
+            "2022-11-19T02:00:00",
+            "2021-11-21T03:00:00",
+            "2021-11-21T04:00:00",
+        ],
+        tz="utc",
+    )
     assert_index_equal(
-        x_years_ago_at_date(
-            event_start=event_start,
-            **knowledge_func_params
+        x_years_ago_at_date(event_start=event_start, **knowledge_func_params),
+        pd.TimedeltaIndex(
+            [
+                timedelta(days=365, hours=1),
+                timedelta(days=364, hours=2),
+                timedelta(days=364, hours=2),
+                timedelta(days=366, hours=3),
+                timedelta(days=366, hours=4),
+            ]
         ),
-        pd.TimedeltaIndex([timedelta(days=365, hours=1), timedelta(days=364, hours=2), timedelta(days=364, hours=2), timedelta(days=366, hours=3), timedelta(days=366, hours=4)]),
     )
 
-    knowledge_func_params_2_years = dict(month=11, day=20, x=2)    
+    knowledge_func_params_2_years = dict(month=11, day=20, x=2)
 
     # Check years parameter
     assert x_years_ago_at_date(
         event_start=datetime(2024, 11, 19, 1, tzinfo=utc),
-        **knowledge_func_params_2_years
-    ) == timedelta(days=2*365, hours=1) # 365 days + 366 days - 1 day
+        **knowledge_func_params_2_years,
+    ) == timedelta(
+        days=2 * 365, hours=1
+    )  # 365 days + 366 days - 1 day
 
 
 def test_dst():

--- a/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
+++ b/timely_beliefs/sensors/func_store/test_knowledge_horizons.py
@@ -6,7 +6,7 @@ from pytz import utc, timezone
 
 from timely_beliefs.sensors.func_store.knowledge_horizons import (
     at_date,
-    at_date_annually,
+    x_years_ago_at_date,
     ex_ante,
     ex_post,
     x_days_ago_at_y_oclock,
@@ -55,57 +55,70 @@ def test_fixed_knowledge_time():
     )
 
 
-def test_at_date_annually():
+def test_x_years_ago_at_date():
     """Check definition of knowledge horizon for events known at a fixed date annually."""
 
     knowledge_func_params = dict(month=11, day=20)    
     
-    # events that occur before the reference
+    # Events that occur before the reference
     # year 2024 is leap
-    assert at_date_annually(
+    assert x_years_ago_at_date(
         event_start=datetime(2024, 11, 19, 1, tzinfo=utc),
         **knowledge_func_params
     ) == timedelta(days=365, hours=1) # 366 days - 1
 
     # year 2025 is not leap, but 2024 is
-    assert at_date_annually(
+    assert x_years_ago_at_date(
         event_start=datetime(2025, 11, 19, 2, tzinfo=utc),
         **knowledge_func_params
     ) == timedelta(days=364, hours=2) # 365 - 1
 
     # year 2023 is not leap and 2022 either
-    assert at_date_annually(
+    assert x_years_ago_at_date(
         event_start=datetime(2022, 11, 19, 2, tzinfo=utc),
         **knowledge_func_params
     ) == timedelta(days=364, hours=2) # 365 - 1
 
-    # events that occur after the reference
-    assert at_date_annually(
+    # Events that occur after the reference
+    assert x_years_ago_at_date(
         event_start=datetime(2021, 11, 21, 3, tzinfo=utc),
         **knowledge_func_params
-    ) == timedelta(days=1, hours=3)
+    ) == timedelta(days=366, hours=3) # 365 + 1
 
-    assert at_date_annually(
+    assert x_years_ago_at_date(
         event_start=datetime(2021, 11, 21, 4, tzinfo=utc),
         **knowledge_func_params
-    ) == timedelta(days=1, hours=4)
+    ) == timedelta(days=366, hours=4) # 365 + 1
+
+    assert x_years_ago_at_date(
+        event_start=datetime(2020, 11, 21, 4, tzinfo=utc),
+        **knowledge_func_params
+    ) == timedelta(days=367, hours=4) # 366 (leap year) + 1
 
     # Test a Daylight Savings Transition
     knowledge_func_params_dst = dict(month=3, day=23) # DST transition 2024
-    assert at_date_annually(
+    assert x_years_ago_at_date(
         event_start=datetime(2024, 3, 25, 0, tzinfo=timezone("Europe/Amsterdam")),
         **knowledge_func_params_dst
-    ) == timedelta(days=2)
+    ) == timedelta(days=368)
 
     # Repeat test with pd.DatetimeIndex instead
     event_start = pd.DatetimeIndex(["2024-11-19T01:00:00", "2025-11-19T02:00:00", "2022-11-19T02:00:00", "2021-11-21T03:00:00", "2021-11-21T04:00:00"], tz="utc")
     assert_index_equal(
-        at_date_annually(
+        x_years_ago_at_date(
             event_start=event_start,
             **knowledge_func_params
         ),
-        pd.TimedeltaIndex([timedelta(days=365, hours=1), timedelta(days=364, hours=2), timedelta(days=364, hours=2), timedelta(days=1, hours=3), timedelta(days=1, hours=4)]),
+        pd.TimedeltaIndex([timedelta(days=365, hours=1), timedelta(days=364, hours=2), timedelta(days=364, hours=2), timedelta(days=366, hours=3), timedelta(days=366, hours=4)]),
     )
+
+    knowledge_func_params_2_years = dict(month=11, day=20, x=2)    
+
+    # Check years parameter
+    assert x_years_ago_at_date(
+        event_start=datetime(2024, 11, 19, 1, tzinfo=utc),
+        **knowledge_func_params_2_years
+    ) == timedelta(days=2*365, hours=1) # 366 days - 1
 
 
 def test_dst():

--- a/timely_beliefs/sensors/func_store/utils.py
+++ b/timely_beliefs/sensors/func_store/utils.py
@@ -47,23 +47,34 @@ def datetime_x_days_ago_at_y_oclock(
     return tz_aware_earlier_time
 
 
-def x_years_ago_at_date_datetime(
-    event_start: datetime, day: int, month: int, x: int, z: str | None
+def datetime_x_years_ago_at_date(
+    event_start: datetime | pd.DatetimeIndex,
+    day: int,
+    month: int,
+    x: int,
+    z: str | None,
 ) -> timedelta:
-    if z is None:
-        z = event_start.tzinfo
+
+    if isinstance(event_start, datetime):
+        if z is None:
+            z = event_start.tzinfo
+        else:
+            z = timezone(z)
+
+        anchor = dict(
+            year=event_start.year - x,
+            month=month,
+            day=day,
+            hour=0,
+            minute=0,
+            second=0,
+            microsecond=0,
+            tzinfo=z,
+        )
+        earlier_time = event_start.replace(**anchor)
     else:
-        z = timezone(z)
+        earlier_time = event_start.to_period("1Y").to_timestamp().tz_localize(
+            event_start.tz
+        ) + pd.DateOffset(month=month, day=day, years=-x)
 
-    anchor = dict(
-        year=event_start.year - x,
-        month=month,
-        day=day,
-        hour=0,
-        minute=0,
-        second=0,
-        microsecond=0,
-        tzinfo=z,
-    )
-
-    return event_start - event_start.replace(**anchor)
+    return earlier_time

--- a/timely_beliefs/sensors/func_store/utils.py
+++ b/timely_beliefs/sensors/func_store/utils.py
@@ -65,15 +65,18 @@ def datetime_x_years_ago_at_date(
         tz_naive_original_time = tz_aware_original_time.astimezone(tz).replace(
             tzinfo=None
         )
-        tz_naive_earlier_time = (pd.Timestamp(tz_naive_original_time).to_period("1Y").to_timestamp() - pd.DateOffset(years=x)).replace(
-            month=month, day=day, hour=h, minute=m, second=s, microsecond=micros
-        )
+        tz_naive_earlier_time = (
+            pd.Timestamp(tz_naive_original_time).to_period("1Y").to_timestamp()
+            - pd.DateOffset(years=x)
+        ).replace(month=month, day=day, hour=h, minute=m, second=s, microsecond=micros)
         tz_aware_earlier_time = tz.localize(tz_naive_earlier_time).astimezone(
             original_tz
         )
     else:
-        tz_aware_earlier_time = tz_aware_original_time.to_period("1Y").to_timestamp().tz_localize(
-            tz_aware_original_time.tz
-        ) + pd.DateOffset(month=month, day=day, years=-x)
+        tz_aware_earlier_time = tz_aware_original_time.to_period(
+            "1Y"
+        ).to_timestamp().tz_localize(tz_aware_original_time.tz) + pd.DateOffset(
+            month=month, day=day, years=-x
+        )
 
     return tz_aware_earlier_time

--- a/timely_beliefs/sensors/func_store/utils.py
+++ b/timely_beliefs/sensors/func_store/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pandas as pd
 from pytz import timezone
@@ -45,3 +45,25 @@ def datetime_x_days_ago_at_y_oclock(
         )
 
     return tz_aware_earlier_time
+
+
+def x_years_ago_at_date_datetime(
+    event_start: datetime, day: int, month: int, x: int, z: str | None
+) -> timedelta:
+    if z is None:
+        z = event_start.tzinfo
+    else:
+        z = timezone(z)
+
+    anchor = dict(
+        year=event_start.year - x,
+        month=month,
+        day=day,
+        hour=0,
+        minute=0,
+        second=0,
+        microsecond=0,
+        tzinfo=z,
+    )
+
+    return event_start - event_start.replace(**anchor)


### PR DESCRIPTION
Recently, we've encountered the case of beliefs that were known at a certain day and month, annually. This PR introduces a new knowledge horizon function which takes a `day` and a `month` as parameters and let's you define a date in which the event was known.

If it happens that the `event_start` is before the publication year at that year, we take the date of previous year as reference.

Regarding testing, I've covered DST and leap years.
