### PR TITLE
Pop `dayfirst` attribute before read_excel.

### DIFF
--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -631,6 +631,9 @@ def read_csv(  # noqa C901
             if col not in kwargs.get("usecols", [])
         ]
     ext = find_out_extension(path)
+    
+    dayfirst = kwargs.pop("dayfirst", None)
+
     if ext.lower() == "csv":
         df = pd.read_csv(path, **kwargs)
     elif ext.lower() in ("xlsm", "xlsx", "xls"):
@@ -639,7 +642,7 @@ def read_csv(  # noqa C901
         raise TypeError(
             f"Extension {ext} not recognized. Accepted file extensions are csv, xlsm, xlsx and xls."
         )
-    dayfirst = kwargs.pop("dayfirst", None)
+
     if filter_by_column:
         # Filter the read-in data
         for col, val in filter_by_column.items():


### PR DESCRIPTION
Pandas `read_csv` function was complaining because we were providing an unexpected keyword argument `dayfirst` and I moved the already existing `pop` call before the function call.

So far, I can't explain why it worked before. Maybe it has to do with the function signature being updated with in a more recent version which doesn't allow for extra arguments.