### PR TITLE
Fast track strategy for searching single recent beliefs

### DIFF
--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -316,8 +316,7 @@ class TimedBeliefDBMixin(TimedBelief):
         source: BeliefSource | list[BeliefSource] | None = None,
         most_recent_beliefs_only: bool = False,
         most_recent_events_only: bool = False,
-        most_recent_belief_only: bool = False,
-        most_recent_event_only: bool = False,
+        most_recent_only: bool = False,
         place_beliefs_in_sensor_timezone: bool = True,
         place_events_in_sensor_timezone: bool = True,
         custom_filter_criteria: list[BinaryExpression] | None = None,
@@ -329,12 +328,12 @@ class TimedBeliefDBMixin(TimedBelief):
         - sensor_class makes it possible to create a query on sensor subclasses
         - custom_join_targets makes it possible to add custom filters using other (incl. subclassed) targets
 
+        A word about query speed:
         As data sets can become quite large (and get wrapped into a BeliefsDataFrame), we recommend to filter by sensor and source, as well as a time range, in order to limit processing time.
-
-        Also,you might usually want to exclude all data outside of the latest beliefs and/or events.
-        To achieve this, use either of two approaches (it's not possible to mix them):
-        - most_recent_[events|beliefs]_only: Using these filters leads to subqueries, which increase processing time. Thus, use together with event_starts_after and event_ends_before if at all possible.
-        - most_recent_[event|belief]_only: A fast-track for getting only one most recent data point (not most recent for each event within a time range).
+        You should also consider selecting only the most recent beliefs (for each event, there might have been more than one).
+        Also, look into selecting only the most recent events (per source).
+        These two latter tips decrease the dataset and thus post-processing time. They use sub-queries, though, so be sure to use the main filtering, as well, like time range.
+        Finally, if you only need one most recent value (one result row), there is a fast-track (most_recent_only).
 
         :param session: the database session to use
         :param sensor: sensor to which the beliefs pertain, or its unique sensor id
@@ -349,11 +348,10 @@ class TimedBeliefDBMixin(TimedBelief):
         :param beliefs_before: only return beliefs formed before this datetime (inclusive)
         :param horizons_at_least: only return beliefs with a belief horizon equal or greater than this timedelta (for example, use timedelta(0) to get ante knowledge time beliefs)
         :param horizons_at_most: only return beliefs with a belief horizon equal or less than this timedelta (for example, use timedelta(0) to get post knowledge time beliefs)
-        :param source: only return beliefs formed by the given source or list of sources
+        :param source: only return beliefs formed by the given source or list of sources. This speeds up your query, so if you know the source, let the query know.
         :param most_recent_beliefs_only: only return the most recent beliefs for each event from each source (minimum belief horizon)
         :param most_recent_events_only: only return (post knowledge time) beliefs for the most recent event (maximum event start) for each source
-        :param most_recent_belief_only: only return the most recent belief of the most recent event that fits all filter criteria (will also apply most_recent_event_only)
-        :param most_recent_event_only: only return the most recent event that fits all filter criteria
+        :param most_recent_only: only looks up one most recent event and then only returns the most recent belief about that event that it finds. This is a considerable fast-track if only one most recent belief is all you need.
         :param place_beliefs_in_sensor_timezone: if True (the default), belief times are converted to the timezone of the sensor
         :param place_events_in_sensor_timezone: if True (the default), event starts are converted to the timezone of the sensor
         :param custom_filter_criteria: additional filters, such as ones that rely on subclasses
@@ -388,6 +386,14 @@ class TimedBeliefDBMixin(TimedBelief):
                 beliefs_before, "belief_before"
             )
 
+        # Parse source parameter
+        sources: list = []
+        if source is not None:
+            sources = [source] if not isinstance(source, list) else source
+            # Fast-track empty list of sources
+            if sources == []:
+                return BeliefsDataFrame(sensor=sensor, beliefs=[])
+
         # Query sensor, required for its timing properties
         if isinstance(sensor, int):
             # Check for proper sensor class
@@ -400,10 +406,6 @@ class TimedBeliefDBMixin(TimedBelief):
             ).scalar_one_or_none()
             if sensor is None:
                 raise ValueError("No such sensor")
-
-        # Fast-track empty list of sources
-        if source == []:
-            return BeliefsDataFrame(sensor=sensor, beliefs=[])
 
         # Get bounds on the knowledge horizon (so we can already roughly filter by belief time)
         (
@@ -500,19 +502,22 @@ class TimedBeliefDBMixin(TimedBelief):
         q = apply_belief_timing_filters(q)
 
         # Apply source filter
-        if source is not None:
-            sources: list = [source] if not isinstance(source, list) else source
+        if len(sources) > 0:
             q = q.join(source_class).filter(cls.source_id.in_([s.id for s in sources]))
 
-        if most_recent_belief_only:
-            # most recent belief only makes sense on one defined event
-            most_recent_event_only = True
-        # make sure we don't mix the two most-recent-X approaches
-        if (most_recent_beliefs_only or most_recent_events_only) and (
-            most_recent_event_only
+        # Switch to fast-track if user wants both most recent events & beliefs and one source is requested.
+        # In this case, we know only one row will be returned. (If only one source exists in the to-be-returned dataset,
+        #  we'd get one row without filtering for source, but we cannot know if that happens before we query.)
+        if (most_recent_beliefs_only and most_recent_events_only) and len(sources) == 1:
+            most_recent_only = True
+            most_recent_events_only = False
+            most_recent_beliefs_only = False
+        # Otherwise, we should not allow to mix the two most-recent-X approaches, for clarity
+        elif (most_recent_beliefs_only or most_recent_events_only) and (
+            most_recent_only
         ):
             raise ValueError(
-                "most_recent_event|belief_only can not be used with either most_recent_beliefs_only or most_recent_events_only."
+                "most_recent_events|beliefs_only can not be used with most_recent_only."
             )
 
         # Apply most recent beliefs filter as subquery
@@ -572,16 +577,11 @@ class TimedBeliefDBMixin(TimedBelief):
                 ),
             )
 
-        # Apply fast-track most recent event|belief only approach
+        # Apply fast-track most-recent-only approach
         # Note that currently, this only works for a deterministic belief. A probabilistic belief would have multiple rows
         # (sharing the same event start and belief horizon).
-        if most_recent_event_only:
-            if most_recent_belief_only:
-                q = q.order_by(cls.event_start.desc(), cls.belief_horizon.asc()).limit(
-                    1
-                )
-            else:
-                q = q.order_by(cls.event_start.desc()).limit(1)
+        if most_recent_only:
+            q = q.order_by(cls.event_start.desc(), cls.belief_horizon.asc()).limit(1)
 
         # Useful debugging code, let's keep it here
         # from sqlalchemy.dialects import postgresql

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -575,7 +575,7 @@ class TimedBeliefDBMixin(TimedBelief):
         # apply fast-track most recent event|belief only approach
         if most_recent_event_only:
             if most_recent_belief_only:
-                q = q.order_by(cls.event_start.desc(), cls.belief_horizon.desc()).limit(
+                q = q.order_by(cls.event_start.desc(), cls.belief_horizon.asc()).limit(
                     1
                 )
             else:

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -193,6 +193,11 @@ class TimedBeliefDBMixin(TimedBelief):
                     "belief_horizon",  # we use min() on this (most_recent_beliefs_only)
                 ],
             ),
+            Index(
+                f"{cls.__tablename__}_search_session_singleevent_idx",
+                "event_start",
+                "sensor_id",
+            ),
         )
 
     event_start = Column(DateTime(timezone=True), primary_key=True, index=True)

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -352,8 +352,8 @@ class TimedBeliefDBMixin(TimedBelief):
         :param source: only return beliefs formed by the given source or list of sources
         :param most_recent_beliefs_only: only return the most recent beliefs for each event from each source (minimum belief horizon)
         :param most_recent_events_only: only return (post knowledge time) beliefs for the most recent event (maximum event start) for each source
-        :param most_recent_belief_only: only return the most recent belief of the most recent event which fits all filter criteria (will also apply most_recent_event_only)
-        :param most_recent_event_only: only return the most recent event which fits all filter criteria
+        :param most_recent_belief_only: only return the most recent belief of the most recent event that fits all filter criteria (will also apply most_recent_event_only)
+        :param most_recent_event_only: only return the most recent event that fits all filter criteria
         :param place_beliefs_in_sensor_timezone: if True (the default), belief times are converted to the timezone of the sensor
         :param place_events_in_sensor_timezone: if True (the default), event starts are converted to the timezone of the sensor
         :param custom_filter_criteria: additional filters, such as ones that rely on subclasses
@@ -572,7 +572,9 @@ class TimedBeliefDBMixin(TimedBelief):
                 ),
             )
 
-        # apply fast-track most recent event|belief only approach
+        # Apply fast-track most recent event|belief only approach
+        # Note that currently, this only works for a deterministic belief. A probabilistic belief would have multiple rows
+        # (sharing the same event start and belief horizon).
         if most_recent_event_only:
             if most_recent_belief_only:
                 q = q.order_by(cls.event_start.desc(), cls.belief_horizon.asc()).limit(
@@ -581,6 +583,7 @@ class TimedBeliefDBMixin(TimedBelief):
             else:
                 q = q.order_by(cls.event_start.desc()).limit(1)
 
+        # Useful debugging code, let's keep it here
         # from sqlalchemy.dialects import postgresql
         # print(q.compile(dialect=postgresql.dialect()))
 

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -386,14 +386,6 @@ class TimedBeliefDBMixin(TimedBelief):
                 beliefs_before, "belief_before"
             )
 
-        # Parse source parameter
-        sources: list = []
-        if source is not None:
-            sources = [source] if not isinstance(source, list) else source
-            # Fast-track empty list of sources
-            if sources == []:
-                return BeliefsDataFrame(sensor=sensor, beliefs=[])
-
         # Query sensor, required for its timing properties
         if isinstance(sensor, int):
             # Check for proper sensor class
@@ -406,6 +398,14 @@ class TimedBeliefDBMixin(TimedBelief):
             ).scalar_one_or_none()
             if sensor is None:
                 raise ValueError("No such sensor")
+
+        # Parse source parameter
+        sources: list = []
+        if source is not None:
+            sources = [source] if not isinstance(source, list) else source
+            # Fast-track empty list of sources
+            if sources == []:
+                return BeliefsDataFrame(sensor=sensor, beliefs=[])
 
         # Get bounds on the knowledge horizon (so we can already roughly filter by belief time)
         (


### PR DESCRIPTION
This PR adds a "ORDER_BY and LIMIT 1" strategy to `search_session()`, which drastically shortens the execution time for queries which really only want one (most recent) belief, e.g. to check connectivity status or show the latest measured value.

In this PR; we add a search filter `most_recent_only` (notice the missing "s"). 
This addition retains backwards compatibility, so packages using timely beliefs should have an easy time starting to use them.

Also, this PR adds an index to make sure the search time is constant, no matter how far in the past the most recent event might be. The index only adds fields used in the ORDER BY which is the recommended practice.

The psql session below demonstrates its effect in such a case (most recent event quite a while in the past - for sensors where the most recent even is really recent, execution time is fast anyway). I repeated each search twice to make sure we see a consistent behavior.

```
flexmeasures_prod=> \timing on
Timing is on.
flexmeasures_prod=> SELECT
timed_belief.event_start,
timed_belief.belief_horizon,
timed_belief.source_id,
timed_belief.cumulative_probability,
timed_belief.event_value
FROM
timed_belief
JOIN data_source ON data_source.id = timed_belief.source_id
WHERE
timed_belief.sensor_id = 4
AND timed_belief.event_start <= '2024-05-03 16:14:33.262614+09:00'
ORDER BY
timed_belief.event_start DESC
LIMIT
1;
      event_start       | belief_horizon | source_id | cumulative_probability |      event_value      
------------------------+----------------+-----------+------------------------+-----------------------
 2023-07-02 14:50:00+00 | 00:00:00       |         5 |                    0.5 | 0.0011505681818181816
(1 row)

Time: 550.283 ms
flexmeasures_prod=> SELECT
timed_belief.event_start,
timed_belief.belief_horizon,
timed_belief.source_id,
timed_belief.cumulative_probability,
timed_belief.event_value
FROM
timed_belief
JOIN data_source ON data_source.id = timed_belief.source_id
WHERE
timed_belief.sensor_id = 4
AND timed_belief.event_start <= '2024-05-03 16:14:33.262614+09:00'
ORDER BY
timed_belief.event_start DESC
LIMIT
1;
      event_start       | belief_horizon | source_id | cumulative_probability |      event_value      
------------------------+----------------+-----------+------------------------+-----------------------
 2023-07-02 14:50:00+00 | 00:00:00       |         5 |                    0.5 | 0.0011505681818181816
(1 row)

Time: 580.948 ms
flexmeasures_prod=> CREATE INDEX timed_belief_simplewhere_idx ON "timed_belief" (sensor_id, event_start);
CREATE INDEX
Time: 6020.611 ms (00:06.021)
flexmeasures_prod=> SELECT                                                                               
timed_belief.event_start,
timed_belief.belief_horizon,
timed_belief.source_id,
timed_belief.cumulative_probability,
timed_belief.event_value
FROM
timed_belief
JOIN data_source ON data_source.id = timed_belief.source_id
WHERE
timed_belief.sensor_id = 4
AND timed_belief.event_start <= '2024-05-03 16:14:33.262614+09:00'
ORDER BY
timed_belief.event_start DESC
LIMIT
1;
      event_start       | belief_horizon | source_id | cumulative_probability |      event_value      
------------------------+----------------+-----------+------------------------+-----------------------
 2023-07-02 14:50:00+00 | 00:00:00       |         5 |                    0.5 | 0.0011505681818181816
(1 row)

Time: 1.480 ms
flexmeasures_prod=> SELECT
timed_belief.event_start,
timed_belief.belief_horizon,
timed_belief.source_id,
timed_belief.cumulative_probability,
timed_belief.event_value
FROM
timed_belief
JOIN data_source ON data_source.id = timed_belief.source_id
WHERE
timed_belief.sensor_id = 4
AND timed_belief.event_start <= '2024-05-03 16:14:33.262614+09:00'
ORDER BY
timed_belief.event_start DESC
LIMIT
1;
      event_start       | belief_horizon | source_id | cumulative_probability |      event_value      
------------------------+----------------+-----------+------------------------+-----------------------
 2023-07-02 14:50:00+00 | 00:00:00       |         5 |                    0.5 | 0.0011505681818181816
(1 row)

Time: 1.047 ms
```

We also need to look into the space we are using with indices.