### PR TITLE
feat: bulk save objects ignoring conflicts

### DIFF
--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -277,22 +277,26 @@ class TimedBeliefDBMixin(TimedBelief):
         """
         # Belief timing is stored as the belief horizon rather than as the belief time
         belief_records = (
-            beliefs_data_frame.convert_index_from_belief_time_to_horizon()
-            .reset_index()
+            beliefs_data_frame.convert_index_from_belief_time_to_horizon().reset_index()
         )
-        beliefs = [cls(sensor=beliefs_data_frame.sensor, **d) for d in belief_records.to_dict("records")]
-        
+        beliefs = [
+            cls(sensor=beliefs_data_frame.sensor, **d)
+            for d in belief_records.to_dict("records")
+        ]
+
         if expunge_session:
             session.expunge_all()
-        
+
         if bulk_save_objects:
             # serialize source and sensor
-            belief_records["source_id"] = belief_records["source"].apply(lambda x: x.id) 
+            belief_records["source_id"] = belief_records["source"].apply(lambda x: x.id)
             belief_records["sensor_id"] = belief_records.sensor.id
             belief_records = belief_records.drop(columns=["source"])
-            
+
             session.execute(
-                insert(cls).values(belief_records.to_dict("records")).on_conflict_do_nothing()
+                insert(cls)
+                .values(belief_records.to_dict("records"))
+                .on_conflict_do_nothing()
             )
         elif not allow_overwrite:
             session.add_all(beliefs)

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -299,7 +299,13 @@ class TimedBeliefDBMixin(TimedBelief):
 
             if allow_overwrite:
                 smt = smt.on_conflict_do_update(
-                    index_elements=["event_start", "belief_horizon", "source_id", "sensor_id", "cumulative_probability"],
+                    index_elements=[
+                        "event_start",
+                        "belief_horizon",
+                        "source_id",
+                        "sensor_id",
+                        "cumulative_probability",
+                    ],
                     set_=dict(event_value=smt.excluded.event_value),
                 )
 

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -295,6 +295,9 @@ class TimedBeliefDBMixin(TimedBelief):
             beliefs_data_frame["sensor_id"] = beliefs_data_frame.sensor.id
             beliefs_data_frame = beliefs_data_frame.drop(columns=["source"])
 
+            if len(beliefs_data_frame) == 0:
+                return
+
             smt = insert(cls).values(beliefs_data_frame.to_dict("records"))
 
             if allow_overwrite:

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -28,6 +28,7 @@ from sqlalchemy import (
     func,
     select,
 )
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
 from sqlalchemy.orm import Session, backref, declarative_mixin, relationship
@@ -35,7 +36,6 @@ from sqlalchemy.orm.util import AliasedClass
 from sqlalchemy.schema import Index
 from sqlalchemy.sql.elements import BinaryExpression
 from sqlalchemy.sql.expression import Selectable
-from sqlalchemy.dialects.postgresql import insert
 
 import timely_beliefs.utils as tb_utils
 from timely_beliefs.beliefs import probabilistic_utils

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -275,6 +275,8 @@ class TimedBeliefDBMixin(TimedBelief):
                                     if False, you can still add other data to the session
                                     and commit it all within an atomic transaction
         """
+        if beliefs_data_frame.empty:
+            return
         # Belief timing is stored as the belief horizon rather than as the belief time
         beliefs_data_frame = (
             beliefs_data_frame.convert_index_from_belief_time_to_horizon().reset_index()
@@ -294,9 +296,6 @@ class TimedBeliefDBMixin(TimedBelief):
             )
             beliefs_data_frame["sensor_id"] = beliefs_data_frame.sensor.id
             beliefs_data_frame = beliefs_data_frame.drop(columns=["source"])
-
-            if len(beliefs_data_frame) == 0:
-                return
 
             smt = insert(cls).values(beliefs_data_frame.to_dict("records"))
 

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -299,7 +299,7 @@ class TimedBeliefDBMixin(TimedBelief):
 
             if allow_overwrite:
                 smt = smt.on_conflict_do_update(
-                    constraint="timed_belief_pkey",
+                    index_elements=["event_start", "belief_horizon", "source_id", "sensor_id", "cumulative_probability"],
                     set_=dict(event_value=smt.excluded.event_value),
                 )
 

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -252,7 +252,7 @@ class TimedBeliefDBMixin(TimedBelief):
         beliefs_data_frame: "BeliefsDataFrame",
         expunge_session: bool = False,
         allow_overwrite: bool = False,
-        bulk_save_objects: bool = False,
+        bulk_save_objects: bool = True,
         commit_transaction: bool = False,
     ):
         """Add a BeliefsDataFrame as timed beliefs to a database session.
@@ -308,6 +308,8 @@ class TimedBeliefDBMixin(TimedBelief):
                     ],
                     set_=dict(event_value=smt.excluded.event_value),
                 )
+            else:
+                smt = smt.on_conflict_do_nothing()
 
             session.execute(smt)
 

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -276,12 +276,12 @@ class TimedBeliefDBMixin(TimedBelief):
                                     and commit it all within an atomic transaction
         """
         # Belief timing is stored as the belief horizon rather than as the belief time
-        belief_records = (
+        beliefs_data_frame = (
             beliefs_data_frame.convert_index_from_belief_time_to_horizon().reset_index()
         )
         beliefs = [
             cls(sensor=beliefs_data_frame.sensor, **d)
-            for d in belief_records.to_dict("records")
+            for d in beliefs_data_frame.to_dict("records")
         ]
 
         if expunge_session:
@@ -289,13 +289,13 @@ class TimedBeliefDBMixin(TimedBelief):
 
         if bulk_save_objects:
             # serialize source and sensor
-            belief_records["source_id"] = belief_records["source"].apply(lambda x: x.id)
-            belief_records["sensor_id"] = belief_records.sensor.id
-            belief_records = belief_records.drop(columns=["source"])
+            beliefs_data_frame["source_id"] = beliefs_data_frame["source"].apply(lambda x: x.id)
+            beliefs_data_frame["sensor_id"] = beliefs_data_frame.sensor.id
+            beliefs_data_frame = beliefs_data_frame.drop(columns=["source"])
 
             session.execute(
                 insert(cls)
-                .values(belief_records.to_dict("records"))
+                .values(beliefs_data_frame.to_dict("records"))
                 .on_conflict_do_nothing()
             )
         elif not allow_overwrite:

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -289,7 +289,9 @@ class TimedBeliefDBMixin(TimedBelief):
 
         if bulk_save_objects:
             # serialize source and sensor
-            beliefs_data_frame["source_id"] = beliefs_data_frame["source"].apply(lambda x: x.id)
+            beliefs_data_frame["source_id"] = beliefs_data_frame["source"].apply(
+                lambda x: x.id
+            )
             beliefs_data_frame["sensor_id"] = beliefs_data_frame.sensor.id
             beliefs_data_frame = beliefs_data_frame.drop(columns=["source"])
 
@@ -298,12 +300,10 @@ class TimedBeliefDBMixin(TimedBelief):
             if allow_overwrite:
                 smt = smt.on_conflict_do_update(
                     constraint="timed_belief_pkey",
-                    set_=dict(event_value=smt.excluded.event_value)
+                    set_=dict(event_value=smt.excluded.event_value),
                 )
 
-            session.execute(
-                smt
-            )
+            session.execute(smt)
 
         else:
             if allow_overwrite:
@@ -311,7 +311,7 @@ class TimedBeliefDBMixin(TimedBelief):
                     session.merge(belief)
             else:
                 session.add_all(beliefs)
-                
+
         if commit_transaction:
             session.commit()
 

--- a/timely_beliefs/tests/conftest.py
+++ b/timely_beliefs/tests/conftest.py
@@ -129,7 +129,6 @@ def test_source_a(db):
     """Define source for test beliefs."""
     source = DBBeliefSource("Source A")
     session.add(source)
-    session.flush()  # assign ID
     return source
 
 
@@ -138,7 +137,6 @@ def test_source_b(db):
     """Define source for test beliefs."""
     source = DBBeliefSource("Source B")
     session.add(source)
-    session.flush()  # assign ID
     return source
 
 
@@ -150,14 +148,14 @@ def test_source_without_initial_data(db):
     return source
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="function", params=[1, 2])
 def rolling_day_ahead_beliefs_about_time_slot_events(
-    request, time_slot_sensor: DBSensor, test_source_b
+    request, time_slot_sensor: DBSensor
 ):
     """Define multiple day-ahead beliefs about an ex post time slot event."""
     source = (
         session.query(DBBeliefSource)
-        .filter(DBBeliefSource.id == test_source_b.id)
+        .filter(DBBeliefSource.id == request.param)
         .one_or_none()
     )
 

--- a/timely_beliefs/tests/conftest.py
+++ b/timely_beliefs/tests/conftest.py
@@ -129,6 +129,7 @@ def test_source_a(db):
     """Define source for test beliefs."""
     source = DBBeliefSource("Source A")
     session.add(source)
+    session.flush()  # assign ID
     return source
 
 
@@ -137,6 +138,7 @@ def test_source_b(db):
     """Define source for test beliefs."""
     source = DBBeliefSource("Source B")
     session.add(source)
+    session.flush()  # assign ID
     return source
 
 
@@ -148,14 +150,14 @@ def test_source_without_initial_data(db):
     return source
 
 
-@pytest.fixture(scope="function", params=[1, 2])
+@pytest.fixture(scope="function")
 def rolling_day_ahead_beliefs_about_time_slot_events(
-    request, time_slot_sensor: DBSensor
+    request, time_slot_sensor: DBSensor, test_source_b
 ):
     """Define multiple day-ahead beliefs about an ex post time slot event."""
     source = (
         session.query(DBBeliefSource)
-        .filter(DBBeliefSource.id == request.param)
+        .filter(DBBeliefSource.id == test_source_b.id)
         .one_or_none()
     )
 

--- a/timely_beliefs/tests/test_belief_persistence.py
+++ b/timely_beliefs/tests/test_belief_persistence.py
@@ -23,7 +23,6 @@ def test_adding_to_session(
         sensor=time_slot_sensor,
         source=test_source_b,
     )
-    assert not bdf.empty
 
     # Replace the source
     if replace_source:

--- a/timely_beliefs/tests/test_belief_persistence.py
+++ b/timely_beliefs/tests/test_belief_persistence.py
@@ -23,6 +23,7 @@ def test_adding_to_session(
         sensor=time_slot_sensor,
         source=test_source_b,
     )
+    assert not bdf.empty
 
     # Replace the source
     if replace_source:

--- a/timely_beliefs/tests/test_belief_persistence.py
+++ b/timely_beliefs/tests/test_belief_persistence.py
@@ -61,9 +61,10 @@ def test_fail_adding_to_session(
         session=session,
         sensor=time_slot_sensor,
     )
+    n_beliefs_before = len(bdf)
 
-    # Attempting to save the same data should fail, even if we expunge everything from the session
-    with pytest.raises(IntegrityError):
+    if bulk_save_objects:
+        # Attempting to save the same data should not yield new data in the database
         DBTimedBelief.add_to_session(
             session,
             bdf,
@@ -71,3 +72,19 @@ def test_fail_adding_to_session(
             bulk_save_objects=bulk_save_objects,
             commit_transaction=True,
         )
+        bdf = DBTimedBelief.search_session(
+            session=session,
+            sensor=time_slot_sensor,
+        )
+        n_beliefs_after = len(bdf)
+        assert n_beliefs_after == n_beliefs_before
+    else:
+        # Attempting to save the same data should fail, even if we expunge everything from the session
+        with pytest.raises(IntegrityError):
+            DBTimedBelief.add_to_session(
+                session,
+                bdf,
+                expunge_session=True,
+                bulk_save_objects=bulk_save_objects,
+                commit_transaction=True,
+            )

--- a/timely_beliefs/tests/test_belief_persistence.py
+++ b/timely_beliefs/tests/test_belief_persistence.py
@@ -83,10 +83,9 @@ def test_adding_to_session_fails(
         session=session,
         sensor=time_slot_sensor,
     )
-    n_beliefs_before = len(bdf)
 
-    if bulk_save_objects:
-        # Attempting to save the same data should not yield new data in the database
+    # Attempting to save the same data should fail, even if we expunge everything from the session
+    with pytest.raises(IntegrityError):
         DBTimedBelief.add_to_session(
             session,
             bdf,
@@ -94,19 +93,3 @@ def test_adding_to_session_fails(
             bulk_save_objects=False,
             commit_transaction=True,
         )
-        bdf = DBTimedBelief.search_session(
-            session=session,
-            sensor=time_slot_sensor,
-        )
-        n_beliefs_after = len(bdf)
-        assert n_beliefs_after == n_beliefs_before
-    else:
-        # Attempting to save the same data should fail, even if we expunge everything from the session
-        with pytest.raises(IntegrityError):
-            DBTimedBelief.add_to_session(
-                session,
-                bdf,
-                expunge_session=True,
-                bulk_save_objects=bulk_save_objects,
-                commit_transaction=True,
-            )


### PR DESCRIPTION
Previously, it wasn't possible to bulk save beliefs with the `allow_overwrite = True`. With the help of `ON CONFLICT DO NOTHING`, we can bulk save beliefs and ignore duplicated key conflicts.