### PR TITLE
Fix: field order in index for most recent event

### DIFF
--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -196,8 +196,8 @@ class TimedBeliefDBMixin(TimedBelief):
             ),
             Index(
                 f"{cls.__tablename__}_search_session_singleevent_idx",
-                "event_start",
                 "sensor_id",
+                "event_start",
             ),
         )
 


### PR DESCRIPTION
The queries we generate use sensor_id first, and it also usually makes the biggest impact in the search space.
