### PR TITLE
fix: UserWarning and PerformanceWarning in `datetime_x_years_ago_at_date`

### DIFF
--- a/timely_beliefs/sensors/func_store/utils.py
+++ b/timely_beliefs/sensors/func_store/utils.py
@@ -73,10 +73,13 @@ def datetime_x_years_ago_at_date(
             original_tz
         )
     else:
-        tz_aware_earlier_time = tz_aware_original_time.to_period(
-            "1Y"
-        ).to_timestamp().tz_localize(tz_aware_original_time.tz) + pd.DateOffset(
-            month=month, day=day, years=-x
+        tz_aware_earlier_time = tz_aware_original_time.map(
+            lambda ts: ts.replace(
+                year=ts.year - x,
+                month=month,
+                day=day,
+                hour=0, minute=0, second=0, microsecond=0
+            )
         )
 
     return tz_aware_earlier_time

--- a/timely_beliefs/sensors/func_store/utils.py
+++ b/timely_beliefs/sensors/func_store/utils.py
@@ -78,7 +78,10 @@ def datetime_x_years_ago_at_date(
                 year=ts.year - x,
                 month=month,
                 day=day,
-                hour=0, minute=0, second=0, microsecond=0
+                hour=0,
+                minute=0,
+                second=0,
+                microsecond=0,
             )
         )
 


### PR DESCRIPTION
fix: `UserWarning: Converting to PeriodArray/Index representation will drop timezone information.` and `PerformanceWarning: Non-vectorized DateOffset being applied to Series or DatetimeIndex.`