### PR TITLE
`BeliefsDataframe` initialization with `pd.Series` if series or index has a name

### DIFF
--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -967,9 +967,7 @@ class BeliefsDataFrame(pd.DataFrame):
             if len(args) > 0 and isinstance(args[0], pd.Series):
                 args = list(args)
                 args[0] = args[0].copy()  # avoid inplace operations
-                args[0] = args[0].to_frame(
-                    name="event_value" if not args[0].name else args[0].name
-                )
+                args[0] = args[0].to_frame(name="event_value")
                 if isinstance(args[0].index, pd.DatetimeIndex) and event_start is None:
                     args[0].index.name = (
                         "event_start" if not args[0].index.name else args[0].index.name

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -969,9 +969,7 @@ class BeliefsDataFrame(pd.DataFrame):
                 args[0] = args[0].copy()  # avoid inplace operations
                 args[0] = args[0].to_frame(name="event_value")
                 if isinstance(args[0].index, pd.DatetimeIndex) and event_start is None:
-                    args[0].index.name = (
-                        "event_start" if not args[0].index.name else args[0].index.name
-                    )
+                    args[0].index.name = "event_start"
                     args[0].reset_index(inplace=True)
                 args = tuple(args)
             elif len(args) > 0 and isinstance(args[0], pd.DataFrame):


### PR DESCRIPTION
- Overwrite the original names when using a `pd.Series` to initialize a `BeliefsDataFrame`
- Rename the value column `"event_value"`
- Rename the datetime index `"event_start"`