### PR TITLE
Chore/resolve SingleBlockManager DeprecationWarning

### DIFF
--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -844,6 +844,7 @@ class BeliefsDataFrame(pd.DataFrame):
         return f
 
     if version.parse(pd.__version__) >= version.parse("2.2.0"):
+
         def _constructor_from_mgr(self, mgr, axes):
             df = BeliefsDataFrame._from_mgr(mgr, axes)
             for name in self._metadata:


### PR DESCRIPTION
Deal with `DeprecationWarning: Passing a SingleBlockManager to BeliefsSeries is deprecated and will raise in a future version. Use public APIs instead.`

If we're lucky, this also deals with another warning we started encountering: `SAWarning: Object of type <TimedBelief> not in session, add operation along 'DataSource.beliefs' will not proceed (This warning originated from the Session 'autoflush' process, which was invoked automatically in response to a user-initiated operation. Consider using ``no_autoflush`` context manager if this warning happened while initializing objects.)`