### PR TITLE
Feat/drop unchanged beliefs

### DIFF
--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -392,6 +392,9 @@ def resample_event_start(
         )
     else:
         # slower
+        # Drop unchanged beliefs before resampling (minimize number of unique belief times)
+        df = drop_unchanged_beliefs(df)
+
         # Propagate beliefs so that each event has the same set of unique belief times
         df = align_belief_times(df, unique_belief_times)
 
@@ -407,6 +410,9 @@ def resample_event_start(
     df = join_beliefs(
         df, output_resolution, input_resolution, distribution=distribution
     )
+
+    # Drop unchanged beliefs after resampling
+    df = drop_unchanged_beliefs(df)
 
     return df
 

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -1329,8 +1329,11 @@ def _drop_unchanged_beliefs_compared_to_db(
     if bdf_db.empty:
         return bdf
 
+    bdf_db_aligned = align_belief_times(
+        bdf_db, pd.Index.union(bdf_db.belief_times.unique(), bdf.belief_times.unique())
+    )
     bdf_wide = beliefs_long_to_wide(bdf)
-    bdf_db_wide = beliefs_long_to_wide(bdf_db)
+    bdf_db_wide = beliefs_long_to_wide(bdf_db_aligned)
 
     # Convert to “full timestamp” index if needed
     bdf_conv = bdf_wide.convert_index_from_belief_horizon_to_time()

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -1320,7 +1320,6 @@ def _drop_unchanged_beliefs_compared_to_db(
     bdf_db = timed_belief_class.search_session(
         session=session,
         sensor=bdf.sensor,
-        sensor_class=type(bdf.sensor),
         event_starts_after=bdf.event_starts[0],
         event_ends_before=bdf.event_ends[-1],
         most_recent_beliefs_only=False,

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -1255,8 +1255,8 @@ def drop_unchanged_beliefs(
     ex_post_bdf = bdf[bdf.belief_horizons <= timedelta(0)]
     if not ex_ante_bdf.empty and not ex_post_bdf.empty:
         # We treat each part separately to avoid that ex-post knowledge would be lost
-        ex_ante_bdf = drop_unchanged_beliefs(ex_ante_bdf)
-        ex_post_bdf = drop_unchanged_beliefs(ex_post_bdf)
+        ex_ante_bdf = drop_unchanged_beliefs(ex_ante_bdf, session=session)
+        ex_post_bdf = drop_unchanged_beliefs(ex_post_bdf, session=session)
         bdf = pd.concat([ex_ante_bdf, ex_post_bdf])
         return bdf
 

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -1287,12 +1287,12 @@ def _drop_unchanged_beliefs_compared_to_db(
     bdf: classes.BeliefsDataFrame,
     session: Session,
 ) -> classes.BeliefsDataFrame:
-    """
-    Drop beliefs from `bdf` that are already present in `bdf_db` at an earlier belief time.
-    Assumes bdf has a unique belief_time and unique source (slice semantics).
-    Vectorized: no reset_index()/set_index() round trips.
+    """Drop beliefs that are already stored in the database with an earlier belief time.
+
+    Assumes a BeliefsDataFrame with either all ex-ante beliefs or all ex-post beliefs.
     """
 
+    # Look up only ex-ante beliefs (horizon > 0) or only ex-post beliefs (horizon <= 0)
     is_ex_ante = bdf.belief_horizons[0] > timedelta(0)
     lookup = dict(horizons_at_least=timedelta(0)) if is_ex_ante else dict(horizons_at_most=timedelta(0))
 

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -1228,3 +1228,107 @@ def upsample_beliefs_data_frame(
         df = df.replace(unique_event_value_not_in_df, np.NaN)
     df.event_resolution = event_resolution
     return df
+
+
+def drop_unchanged_beliefs(bdf: classes.BeliefsDataFrame) -> classes.BeliefsDataFrame:
+    """Drop beliefs that are already stored in the database with an earlier belief time.
+
+    Also drop beliefs that are already in the data with an earlier belief time.
+
+    Quite useful function to prevent cluttering up your database with beliefs that remain unchanged over time.
+    """
+    if bdf.empty:
+        return bdf
+
+    # Save the oldest ex-post beliefs explicitly, even if they do not deviate from the most recent ex-ante beliefs
+    ex_ante_bdf = bdf[bdf.belief_horizons > timedelta(0)]
+    ex_post_bdf = bdf[bdf.belief_horizons <= timedelta(0)]
+    if not ex_ante_bdf.empty and not ex_post_bdf.empty:
+        # We treat each part separately to avoid that ex-post knowledge would be lost
+        ex_ante_bdf = drop_unchanged_beliefs(ex_ante_bdf)
+        ex_post_bdf = drop_unchanged_beliefs(ex_post_bdf)
+        bdf = pd.concat([ex_ante_bdf, ex_post_bdf])
+        return bdf
+
+    # Remove unchanged beliefs from within the new data itself
+    index_names = bdf.index.names
+    bdf = (
+        bdf.sort_index()
+        .reset_index()
+        .drop_duplicates(
+            ["event_start", "source", "cumulative_probability", "event_value"],
+            keep="first",
+        )
+        .set_index(index_names)
+    )
+
+    # Remove unchanged beliefs with respect to what is already stored in the database
+    if bdf.belief_horizons[0] > timedelta(0):
+        # Look up only ex-ante beliefs (horizon > 0)
+        kwargs = dict(horizons_at_least=timedelta(0))
+    else:
+        # Look up only ex-post beliefs (horizon <= 0)
+        kwargs = dict(horizons_at_most=timedelta(0))
+    bdf_db = bdf.sensor.search_beliefs(
+        event_starts_after=bdf.event_starts[0],
+        event_ends_before=bdf.event_ends[-1],
+        most_recent_beliefs_only=False,  # all beliefs
+        **kwargs,
+    )
+    if bdf_db.empty:
+        return bdf
+    return (
+        bdf.convert_index_from_belief_horizon_to_time()
+        .groupby(
+            level=["event_start", "belief_time", "source"],
+            group_keys=False,
+            as_index=False,
+        )
+        .apply(_drop_unchanged_beliefs_compared_to_db, bdf_db=bdf_db)
+    )
+
+
+def _drop_unchanged_beliefs_compared_to_db(
+    bdf: classes.BeliefsDataFrame,
+    bdf_db: classes.BeliefsDataFrame,
+) -> classes.BeliefsDataFrame:
+    """Drop beliefs that are already stored in the database with an earlier belief time.
+
+    Assumes a BeliefsDataFrame with a unique belief time and unique source,
+    and either all ex-ante beliefs or all ex-post beliefs.
+
+    It is preferable to call the public function drop_unchanged_beliefs instead.
+    """
+    source = bdf.lineage.sources[0]  # unique source
+    belief_time = bdf.lineage.belief_times[0]  # unique belief time
+    bdf_db_from_source = bdf_db[bdf_db.sources == source]
+    if bdf_db_from_source.empty:
+        return bdf
+    cutoff_idx = bdf_db_from_source.belief_times.searchsorted(belief_time, side="right")
+    if cutoff_idx == 0:
+        # No earlier belief time in db
+        return bdf
+    most_recent_bt = bdf_db_from_source.belief_times[cutoff_idx - 1]
+    previous_most_recent_beliefs = bdf_db_from_source[
+        bdf_db_from_source.belief_times == most_recent_bt
+    ]
+    if previous_most_recent_beliefs.empty:
+        return bdf
+    compare_fields = ["event_start", "source", "cumulative_probability", "event_value"]
+    a = bdf.reset_index().set_index(compare_fields)
+    b = previous_most_recent_beliefs.reset_index().set_index(compare_fields)
+    bdf = a.drop(
+        b.index,
+        errors="ignore",
+        axis=0,
+    )
+
+    # Keep whole probabilistic beliefs, not just the parts that changed
+    c = bdf.reset_index().set_index(["event_start", "source"])
+    d = a.reset_index().set_index(["event_start", "source"])
+    bdf = d[d.index.isin(c.index)]
+
+    bdf = bdf.reset_index().set_index(
+        ["event_start", "belief_time", "source", "cumulative_probability"]
+    )
+    return bdf

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -1306,6 +1306,8 @@ def _drop_unchanged_beliefs_compared_to_db(
 
     Assumes a BeliefsDataFrame with either all ex-ante beliefs or all ex-post beliefs.
     """
+    if bdf.empty:
+        return bdf
 
     # Look up only ex-ante beliefs (horizon > 0) or only ex-post beliefs (horizon <= 0)
     is_ex_ante = bdf.belief_horizons[0] > timedelta(0)

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -1335,9 +1335,10 @@ def _drop_unchanged_beliefs_compared_to_db(
     bdf_wide = beliefs_long_to_wide(bdf)
     bdf_db_wide = beliefs_long_to_wide(bdf_db_aligned)
 
-    for col in bdf_wide.columns:
-        if col not in bdf_db_wide.columns:
-            bdf_db_wide[col] = np.nan
+    # Ensure that bdf_db_wide contains all the cp values that bdf_wide might have
+    bdf_db_wide = bdf_db_wide.reindex(
+        columns=bdf_wide.columns.union(bdf_db_wide.columns)
+    )
 
     # Convert to “full timestamp” index if needed
     bdf_conv = bdf_wide.convert_index_from_belief_horizon_to_time()

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -1269,13 +1269,11 @@ def drop_unchanged_beliefs(
     # 1. Compare to self
     bdf = _drop_unchanged_beliefs_internally(bdf)
 
-    if not session:
-        return bdf
-
     # 2. Compare to DB (ex-ante or ex-post depending on the first row)
-    bdf = _drop_unchanged_beliefs_compared_to_db(
-        bdf, timed_belief_class=timed_belief_class, session=session
-    )
+    if session:
+        bdf = _drop_unchanged_beliefs_compared_to_db(
+            bdf, timed_belief_class=timed_belief_class, session=session
+        )
 
     return bdf
 

--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -1335,6 +1335,10 @@ def _drop_unchanged_beliefs_compared_to_db(
     bdf_wide = beliefs_long_to_wide(bdf)
     bdf_db_wide = beliefs_long_to_wide(bdf_db_aligned)
 
+    for col in bdf_wide.columns:
+        if col not in bdf_db_wide.columns:
+            bdf_db_wide[col] = np.nan
+
     # Convert to “full timestamp” index if needed
     bdf_conv = bdf_wide.convert_index_from_belief_horizon_to_time()
 


### PR DESCRIPTION
- [x] Upsampling was creating a lot of unchanged beliefs. I moved over the relevant methods from FlexMeasures, which dealt with dropping unchanged beliefs, and applied them in `resample_event_start`.
- [x] I then vectorized the code.
- [ ] Make sure `_drop_unchanged_beliefs_internally` also is robust against probabilistic beliefs.