### PR TITLE
fix: drop exact duplicate rows on CSV upload

### DIFF
--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -747,6 +747,9 @@ def read_csv(  # noqa C901
     elif round_event_start:
         df["event_start"] = df["event_start"].dt.round(sensor.event_resolution)
 
+    # Drop exact duplicate rows (same event_start, value, ...)
+    df = df.drop_duplicates()
+
     # Construct BeliefsDataFrame
     bdf = classes.BeliefsDataFrame(df, sensor=sensor)
 


### PR DESCRIPTION
## Description

This PR improves ease of use for file uploads by removing exact duplicate rows
(same timestamps and values) during CSV import.

Duplicates are dropped silently and do not affect irregular-timestamp validation
or other upload behavior.

## Scope

- Drop exact duplicate rows in `read_csv`
- No changes to validation or error handling

closes #208 