### PR TITLE
feat: Improve error message for irregular timestamps during CSV upload

### DIFF
--- a/timely_beliefs/beliefs/utils.py
+++ b/timely_beliefs/beliefs/utils.py
@@ -765,16 +765,15 @@ def read_csv(  # noqa C901
             irregular = diffs[diffs != mode_diff]
 
             if not irregular.empty:
-                # Limit number of timestamps shown to keep error readable
-                max_shown = 10
-                problematic_starts = event_starts.loc[irregular.index][:max_shown]
+                # Just show the first problematic start to keep error readable
+                first_problematic_start = event_starts.loc[irregular.index[0]]
 
                 raise ValueError(
                     "Could not infer a regular event frequency from the data. "
                     f"Most common frequency: {mode_diff}. "
-                    f"Found {len(irregular)} irregular intervals. "
-                    "First problematic event starts: "
-                    f"{problematic_starts.tolist()}"
+                    f"Number of irregular intervals: {len(irregular)}. "
+                    "First irregular event start: "
+                    f"{first_problematic_start}."
                 )
 
     # Construct BeliefsDataFrame


### PR DESCRIPTION
## Description

Improve the error message raised during CSV upload when event_start timestamps
do not have a regular frequency.

Instead of a generic failure, the error now reports:
- the expected time step
- how many irregular intervals were found
- the first few timestamps that cause the problem

## Motivation

Users currently receive a non-actionable error when timestamp frequency cannot
be inferred. This change makes it clear which rows need fixing.

## Scope

- Detect irregular event_start intervals in `read_csv`
- Raise a clear, user-facing error message
- No automatic fixing or resampling

