### PR TITLE
fix: mview predicate pushdown and correctness hardening in `search_session`

### DIFF
--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -474,32 +474,41 @@ class TimedBeliefDBMixin(TimedBelief):
             get_bounds=True,
         )
 
-        def apply_event_timing_filters(q):
+        def apply_event_timing_filters(q, event_start_col=None):
             """Apply filters that concern the event time.
 
-            This includes any custom filters
+            This includes any custom filters.
+
+            By default, filters are applied to the beliefs table's event_start column.
+            Pass event_start_col to apply the same (event_start-only) bounds to another
+            selectable that has an event_start column of its own, such as the
+            materialized view backing most_recent_beliefs_only queries. This lets those
+            bounds be pushed down into the materialized view subquery, so Postgres can
+            use its indexes instead of scanning (and hash-joining) the entire view.
             """
+            if event_start_col is None:
+                event_start_col = cls.event_start
             if not pd.isnull(event_starts_after):
-                q = q.filter(cls.event_start >= event_starts_after)
+                q = q.filter(event_start_col >= event_starts_after)
             if not pd.isnull(event_ends_after):
                 if sensor.event_resolution == timedelta(0):
                     # inclusive
-                    q = q.filter(cls.event_start >= event_ends_after)
+                    q = q.filter(event_start_col >= event_ends_after)
                 else:
                     # exclusive
                     q = q.filter(
-                        cls.event_start > event_ends_after - sensor.event_resolution
+                        event_start_col > event_ends_after - sensor.event_resolution
                     )
             if not pd.isnull(event_starts_before):
                 if sensor.event_resolution == timedelta(0):
                     # inclusive
-                    q = q.filter(cls.event_start <= event_starts_before)
+                    q = q.filter(event_start_col <= event_starts_before)
                 else:
                     # exclusive
-                    q = q.filter(cls.event_start < event_starts_before)
+                    q = q.filter(event_start_col < event_starts_before)
             if not pd.isnull(event_ends_before):
                 q = q.filter(
-                    cls.event_start <= event_ends_before - sensor.event_resolution
+                    event_start_col <= event_ends_before - sensor.event_resolution
                 )
 
             return q
@@ -619,6 +628,12 @@ class TimedBeliefDBMixin(TimedBelief):
                     mview.c.source_id,
                     mview.c.most_recent_belief_horizon,
                 ).filter(mview.c.sensor_id == sensor.id)
+                # Push the same event_start bounds down into the mview select, so
+                # Postgres can use the mview's indexes instead of scanning (and
+                # hash-joining) the entire view.
+                mview_select = apply_event_timing_filters(
+                    mview_select, mview.c.event_start
+                )
                 if mview_cutoff is not None:
                     # Only trust the view for events starting before the cutoff;
                     # look up later events in the beliefs table instead, so events

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import math
 import operator
 import types
@@ -37,8 +38,9 @@ from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
 from sqlalchemy.orm import Session, backref, declarative_mixin, relationship
 from sqlalchemy.orm.util import AliasedClass
 from sqlalchemy.schema import Index
-from sqlalchemy.sql.elements import BinaryExpression
+from sqlalchemy.sql.elements import BinaryExpression, ColumnClause, TextClause
 from sqlalchemy.sql.expression import Selectable
+from sqlalchemy.sql.visitors import iterate
 
 import timely_beliefs.utils as tb_utils
 from timely_beliefs.beliefs import probabilistic_utils
@@ -52,6 +54,8 @@ from timely_beliefs.sensors.func_store.knowledge_horizons import ex_ante, ex_pos
 from timely_beliefs.sources import utils as source_utils
 from timely_beliefs.sources.classes import BeliefSource, DBBeliefSource
 
+logger = logging.getLogger(__name__)
+
 METADATA = ["sensor", "event_resolution"]
 DatetimeLike = Union[datetime, str, pd.Timestamp]
 TimedeltaLike = Union[timedelta, str, pd.Timedelta]
@@ -61,6 +65,43 @@ JoinTarget = Union[
     AliasedClass,
     types.FunctionType,
 ]
+
+# Columns of the beliefs table that are constant within one (event_start, source_id)
+# group, and can therefore be safely referenced by a custom filter criterion that is
+# applied after (rather than before) the materialized view's MIN(belief_horizon)
+# aggregation, without changing the outcome.
+GROUP_CONSTANT_BELIEFS_COLUMNS = {"sensor_id", "event_start", "source_id"}
+
+
+def _custom_criteria_are_group_constant(
+    criteria: list[BinaryExpression],
+    beliefs_table: Table,
+    allowed_columns: set[str] = GROUP_CONSTANT_BELIEFS_COLUMNS,
+) -> bool:
+    """Return True iff every criterion only references columns that are constant
+    within one (event_start, source_id) group of the beliefs table, so applying
+    the criterion after the mview join yields the same result as applying it
+    before the MIN(belief_horizon) aggregation in the fallback subquery.
+
+    Conservative: any construct we cannot positively introspect (e.g. text()
+    clauses, or bare columns without a known table) counts as not group-constant.
+    """
+    for criterion in criteria:
+        for element in iterate(criterion):
+            if isinstance(element, TextClause):
+                # Cannot introspect literal SQL; assume unsafe.
+                return False
+            if isinstance(element, ColumnClause):
+                if element.table is None:
+                    # E.g. sqlalchemy.column("x") with no known table; assume unsafe.
+                    return False
+                if element.table is beliefs_table:
+                    if element.name not in allowed_columns:
+                        return False
+                # Columns of other tables (e.g. reached via the source_id join)
+                # are constant within a (event_start, source_id) group, so they
+                # are safe regardless of their name.
+    return True
 
 
 class TimedBelief(object):
@@ -477,8 +518,6 @@ class TimedBeliefDBMixin(TimedBelief):
         def apply_event_timing_filters(q, event_start_col=None):
             """Apply filters that concern the event time.
 
-            This includes any custom filters.
-
             By default, filters are applied to the beliefs table's event_start column.
             Pass event_start_col to apply the same (event_start-only) bounds to another
             selectable that has an event_start column of its own, such as the
@@ -516,7 +555,7 @@ class TimedBeliefDBMixin(TimedBelief):
         def apply_belief_timing_filters(q):
             """Apply filters that concern the belief timing.
 
-            This includes any custom filters
+            This includes any custom filter criteria and join targets.
             """
 
             # Apply rough belief time filter
@@ -610,17 +649,52 @@ class TimedBeliefDBMixin(TimedBelief):
                 )
 
             # The materialized view caches the global minimum belief horizon,
-            # so it cannot be used when belief timing filters are set.
+            # so it cannot be used when belief timing filters (rough belief-time
+            # bounds or horizon bounds) are set, since the fallback subquery
+            # applies those filters BEFORE taking MIN(belief_horizon), whereas
+            # the mview only has the unfiltered global minimum cached. Likewise,
+            # it cannot be used for custom filter criteria whose truth value can
+            # vary within a (event_start, source_id) group of the beliefs table
+            # (e.g. a criterion on event_value or belief_horizon), for the same
+            # reason: the fallback subquery applies custom_filter_criteria before
+            # the MIN, so the mview join (which applies them after) could
+            # silently drop an event whose globally-most-recent belief happens
+            # to fail the criterion, even though an earlier belief for that event
+            # would have passed it.
             mview = None
+            custom_criteria_ok = (
+                custom_filter_criteria is None
+                or len(custom_filter_criteria) == 0
+                or _custom_criteria_are_group_constant(
+                    custom_filter_criteria, cls.__table__
+                )
+            )
             if (
                 use_materialized_view
                 and pd.isnull(horizons_at_least)
                 and pd.isnull(horizons_at_most)
+                and pd.isnull(beliefs_after)
+                and pd.isnull(beliefs_before)
+                and custom_criteria_ok
             ):
                 mview = (
                     most_recent_beliefs_mview
                     if most_recent_beliefs_mview is not None
                     else get_most_recent_beliefs_mview(session)
+                )
+            elif (
+                use_materialized_view
+                and pd.isnull(horizons_at_least)
+                and pd.isnull(horizons_at_most)
+                and pd.isnull(beliefs_after)
+                and pd.isnull(beliefs_before)
+                and not custom_criteria_ok
+            ):
+                logger.debug(
+                    "Bypassing the materialized view for most_recent_beliefs_only, "
+                    "because the given custom filter criteria could not be verified "
+                    "as constant within a (event_start, source_id) group of the "
+                    "beliefs table."
                 )
             if mview is not None:
                 mview_select = select(

--- a/timely_beliefs/tests/test_belief_query.py
+++ b/timely_beliefs/tests/test_belief_query.py
@@ -436,6 +436,54 @@ def test_select_most_recent_deterministic_beliefs(
 
 
 @pytest.mark.parametrize("use_mview", [False, True])
+def test_select_most_recent_beliefs_with_event_window(
+    time_slot_sensor: DBSensor,
+    rolling_day_ahead_beliefs_about_time_slot_events: list[DBTimedBelief],
+    use_mview: bool,
+    refresh_mview,
+):
+    """Check that event window filters (event_starts_after/event_ends_before) are
+    respected when selecting most recent beliefs through the materialized view.
+
+    The mview subquery only carries a sensor_id filter (plus, for the live-tail
+    variant, an event_start < cutoff filter). Without pushing the caller's event
+    window down into that subquery too, the join would still return the right rows
+    (the outer query's own event_start filter would exclude the rest), but at the
+    cost of scanning the entire view. This test protects correctness of the
+    pushed-down filter, i.e. that results are unaffected by the optimization.
+    """
+    refresh_mview()
+
+    event_starts_after = datetime(2050, 1, 3, 15, tzinfo=utc)
+    event_ends_before = datetime(2050, 1, 3, 19, tzinfo=utc)
+
+    # Reference: compute over the full result set, without database-side filtering
+    full_df = DBTimedBelief.search_session(
+        session=session,
+        sensor=time_slot_sensor,
+        most_recent_beliefs_only=False,
+        use_materialized_view=use_mview,
+    )
+    reference_df = belief_utils.select_most_recent_belief(full_df)
+    reference_df = reference_df[
+        (reference_df.event_starts >= event_starts_after)
+        & (reference_df.event_ends <= event_ends_before)
+    ]
+    assert not reference_df.empty
+
+    # Test: apply the event window filters within the query itself
+    df = DBTimedBelief.search_session(
+        session=session,
+        sensor=time_slot_sensor,
+        most_recent_beliefs_only=True,
+        event_starts_after=event_starts_after,
+        event_ends_before=event_ends_before,
+        use_materialized_view=use_mview,
+    )
+    pd.testing.assert_frame_equal(df, reference_df)
+
+
+@pytest.mark.parametrize("use_mview", [False, True])
 def test_select_most_recent_probabilistic_beliefs(
     ex_ante_economics_sensor: DBSensor,
     multiple_probabilistic_day_ahead_beliefs_about_ex_ante_economical_event: list[

--- a/timely_beliefs/tests/test_belief_query.py
+++ b/timely_beliefs/tests/test_belief_query.py
@@ -723,9 +723,7 @@ def test_most_recent_beliefs_with_belief_time_filter_bypasses_mview(
         most_recent_beliefs_only=False,
         use_materialized_view=use_mview,
     )
-    full_df = full_df[
-        full_df.index.get_level_values("belief_time") <= beliefs_before
-    ]
+    full_df = full_df[full_df.index.get_level_values("belief_time") <= beliefs_before]
     reference_df = belief_utils.select_most_recent_belief(full_df)
     assert not reference_df.empty
 

--- a/timely_beliefs/tests/test_belief_query.py
+++ b/timely_beliefs/tests/test_belief_query.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from pytz import utc
-from sqlalchemy import select
+from sqlalchemy import and_, select, text
 
 import timely_beliefs.beliefs.queries as query_utils
 import timely_beliefs.beliefs.utils as belief_utils
@@ -17,6 +17,7 @@ from timely_beliefs import (
     DBTimedBelief,
     TimedBelief,
 )
+from timely_beliefs.beliefs.classes import _custom_criteria_are_group_constant
 from timely_beliefs.tests import session
 
 
@@ -688,3 +689,153 @@ def test_mview_returns_stale_most_recent_beliefs_until_refreshed(
     # After a refresh, the view catches up
     refresh_mview()
     assert search(use_materialized_view=True)["event_value"].tolist() == [999]
+
+
+@pytest.mark.parametrize("use_mview", [False, True])
+def test_most_recent_beliefs_with_belief_time_filter_bypasses_mview(
+    time_slot_sensor: DBSensor,
+    rolling_day_ahead_beliefs_about_time_slot_events: list[DBTimedBelief],
+    use_mview: bool,
+    refresh_mview,
+):
+    """A beliefs_before/beliefs_after filter cannot be applied to the materialized view.
+
+    The view caches the global minimum belief horizon (per event, per source), computed
+    without regard to any belief-time window. If we naively joined the (unfiltered) view
+    and then filtered by belief time afterwards, we could silently drop events whose
+    globally-most-recent belief falls outside the window, even though an earlier belief
+    (within the window) exists for that same event.
+
+    time_slot_sensor's knowledge horizon function is ex_post (the default), so it is
+    eligible for the most_recent_beliefs_only mview branch even with beliefs_before set;
+    this test therefore protects the fix at the mview-eligibility level (not just via the
+    post-processing fallback for knowledge functions incompatible with the mview branch
+    altogether).
+    """
+    refresh_mview()
+
+    beliefs_before = datetime(2050, 1, 1, 14, tzinfo=utc)
+
+    # Reference: compute over the full result set, without database-side filtering
+    full_df = DBTimedBelief.search_session(
+        session=session,
+        sensor=time_slot_sensor,
+        most_recent_beliefs_only=False,
+        use_materialized_view=use_mview,
+    )
+    full_df = full_df[
+        full_df.index.get_level_values("belief_time") <= beliefs_before
+    ]
+    reference_df = belief_utils.select_most_recent_belief(full_df)
+    assert not reference_df.empty
+
+    # Test: apply the belief_before filter within the query itself
+    df = DBTimedBelief.search_session(
+        session=session,
+        sensor=time_slot_sensor,
+        most_recent_beliefs_only=True,
+        beliefs_before=beliefs_before,
+        use_materialized_view=use_mview,
+    )
+    pd.testing.assert_frame_equal(df, reference_df)
+
+
+@pytest.mark.parametrize("use_mview", [False, True])
+def test_most_recent_beliefs_with_row_level_custom_criterion_bypasses_mview(
+    ex_ante_economics_sensor: DBSensor,
+    multiple_day_ahead_beliefs_about_ex_ante_economical_event: list[DBTimedBelief],
+    use_mview: bool,
+    refresh_mview,
+):
+    """A custom filter criterion whose truth value can vary within a single
+    (event_start, source_id) group (e.g. a criterion on event_value) cannot be applied to
+    the materialized view, for the same reason belief-time filters cannot: the mview only
+    caches the *globally* most recent belief horizon, so applying such a criterion after
+    the join could silently drop an event whose most recent belief fails the criterion,
+    even though an earlier belief for that event would have passed it.
+
+    The fixture creates 10 beliefs about a single event, with event_value 10 (most
+    recent belief) up to 19 (oldest belief). Filtering out event_value == 10 forces the
+    correct answer to be the second most recent belief (event_value 11); a mview that
+    (incorrectly) caches the unfiltered global minimum belief horizon and applies the
+    criterion only after the join would instead drop the event entirely.
+    """
+    refresh_mview()
+
+    # Reference: compute over the full result set, without database-side filtering
+    full_df = DBTimedBelief.search_session(
+        session=session,
+        sensor=ex_ante_economics_sensor,
+        most_recent_beliefs_only=False,
+        use_materialized_view=use_mview,
+    )
+    full_df = full_df[full_df["event_value"] > 10]
+    reference_df = belief_utils.select_most_recent_belief(full_df)
+    assert not reference_df.empty
+    assert reference_df["event_value"].tolist() == [11]
+
+    df = DBTimedBelief.search_session(
+        session=session,
+        sensor=ex_ante_economics_sensor,
+        most_recent_beliefs_only=True,
+        custom_filter_criteria=[DBTimedBelief.event_value > 10],
+        use_materialized_view=use_mview,
+    )
+    pd.testing.assert_frame_equal(df, reference_df)
+
+
+def test_custom_criteria_are_group_constant_helper():
+    """Unit tests for the conservative introspection helper that decides whether custom
+    filter criteria are safe to apply after (rather than before) the materialized view's
+    MIN(belief_horizon) aggregation.
+    """
+    beliefs_table = DBTimedBelief.__table__
+    source_table = DBBeliefSource.__table__
+
+    # A criterion on a column of another table (e.g. the source class, joined via
+    # source_id) is group-constant and safe.
+    assert _custom_criteria_are_group_constant(
+        [source_table.c.name == "Source A"], beliefs_table
+    )
+
+    # Criteria on the beliefs table's own group-constant columns are safe.
+    assert _custom_criteria_are_group_constant(
+        [DBTimedBelief.event_start == datetime(2020, 1, 1, tzinfo=utc)],
+        beliefs_table,
+    )
+    assert _custom_criteria_are_group_constant(
+        [DBTimedBelief.source_id == 1], beliefs_table
+    )
+
+    # Criteria on beliefs-table columns that can vary within a group are unsafe.
+    assert not _custom_criteria_are_group_constant(
+        [DBTimedBelief.event_value < 1000], beliefs_table
+    )
+    assert not _custom_criteria_are_group_constant(
+        [DBTimedBelief.belief_horizon > timedelta(0)], beliefs_table
+    )
+
+    # A text() clause cannot be introspected, so it is conservatively unsafe.
+    assert not _custom_criteria_are_group_constant([text("1=1")], beliefs_table)
+
+    # A mixed and_() is unsafe if any part of it is unsafe.
+    assert not _custom_criteria_are_group_constant(
+        [
+            and_(
+                DBTimedBelief.source_id == 1,
+                DBTimedBelief.event_value < 1000,
+            )
+        ],
+        beliefs_table,
+    )
+
+    # ... but safe if every part of it is safe.
+    assert _custom_criteria_are_group_constant(
+        [
+            and_(
+                DBTimedBelief.source_id == 1,
+                DBTimedBelief.event_start == datetime(2020, 1, 1, tzinfo=utc),
+            )
+        ],
+        beliefs_table,
+    )


### PR DESCRIPTION
Two related fixes to how `search_session` uses the materialized view backing `most_recent_beliefs_only` queries: a predicate-pushdown performance fix, and a hardening commit closing two correctness holes where the mview could silently drop events.

## 1. Push event window filters down into the mview subquery

The mview join only filtered the materialized view by `sensor_id` (plus `event_start < cutoff` in the live-tail union branch), without repeating the caller's `event_starts_after` / `event_ends_before` / `event_starts_before` / `event_ends_after` bounds. Postgres does not propagate range predicates across the equijoin, so every windowed query forced a full scan (and hash join) of the entire mview for that sensor.

`apply_event_timing_filters` now accepts an optional `event_start` column, and is applied to the mview select in both the mview-only branch and the live-tail UNION branch (combined with the existing `event_start < cutoff` predicate there).

Measured on a FlexMeasures dev db (3.6M-row mview, 365-day window): 755 ms before (Parallel Seq Scan over 3.2M mview rows, hash join spilling 32 batches to disk) vs 311 ms after (Bitmap Index Scan, ~35K rows). In the FlexMeasures query path, this took the mview from consistently *losing* to the fallback (up to 5.8x slower at a 30-day window) to beating it (1.4–1.5x faster).

## 2. Disable the mview when filters could change which belief is "most recent"

The mview caches the *unfiltered* global `MIN(belief_horizon)` per `(sensor, event, source)`, while the fallback subquery applies filters *before* taking the minimum. Whenever a filter can exclude the globally-most-recent belief, joining against the mview silently drops the whole event from the result, instead of returning the most recent belief among the eligible rows. Two eligibility gaps allowed that to happen:

- **Belief-time filters**: `beliefs_after` / `beliefs_before` can be set while the `most_recent_beliefs_only` branch proceeds (for sensors with ex-ante/ex-post knowledge functions), and the eligibility check only looked at `horizons_at_least/at_most`. The mview is now also disabled when belief-time filters are set.
- **Row-level custom filter criteria**: `custom_filter_criteria` are applied before the `MIN` in the fallback, but cannot be applied to the mview (they reference beliefs-table columns the view does not have). A criterion is safe only if its truth value cannot vary within one `(event_start, source_id)` group — i.e. it references no beliefs-table columns other than the group-constant `sensor_id` / `event_start` / `source_id` (columns of other tables, such as the source table, are group-constant via the `source_id` join). A new `_custom_criteria_are_group_constant` helper introspects each criterion with `sqlalchemy.sql.visitors.iterate` and disables the mview otherwise.

The introspection is deliberately conservative and fail-safe: anything it cannot positively verify (e.g. `text()` clauses) disables the mview — a performance fallback, never a correctness risk — with a debug log line for observability. Callers with source-level criteria (like FlexMeasures' source-type filters) keep the optimization automatically, and no caller-declared trust flag is needed.

Also removes a stale "This includes any custom filters" sentence from `apply_event_timing_filters`' docstring (custom criteria are applied in `apply_belief_timing_filters`).

## Tests

- `test_select_most_recent_beliefs_with_event_window` — windowed `most_recent_beliefs_only` query, result equality between mview and non-mview paths.
- `test_most_recent_beliefs_with_belief_time_filter_bypasses_mview` — with `beliefs_before` set on an ex-post sensor, both paths agree.
- `test_most_recent_beliefs_with_row_level_custom_criterion_bypasses_mview` — constructed so the globally-most-recent belief fails the criterion, i.e. it genuinely exercises the missing-events bug.
- `test_custom_criteria_are_group_constant_helper` — unit coverage of the introspection helper (source-table columns, group-constant beliefs columns, row-level columns, `text()`, mixed `and_()`).

Full run of `test_belief_query.py` + `test_belief_persistence.py`: 83 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4jYQMv87WJt1Y1SB7gi1w
