### PR TITLE
fix: make BeliefSource ordering a strict total order

### DIFF
--- a/timely_beliefs/sources/classes.py
+++ b/timely_beliefs/sources/classes.py
@@ -32,8 +32,15 @@ class BeliefSource(object):
         return self.name
 
     def __lt__(self, other):
-        """Set a rule for ordering."""
-        return self.__str__() < other.__str__()
+        """Set a rule for ordering: by string representation, tie-broken by object identity.
+
+        The tie-break makes the ordering a strict total order consistent with the
+        (identity-based) equality, also for distinct sources sharing a name.
+        Without it, sorting is ill-defined for such sources, and pandas operations
+        that sort an index level and then search it (e.g. pd.concat unioning the
+        source level of several BeliefsDataFrames) can silently map sources to NaN.
+        """
+        return (self.__str__(), id(self)) < (other.__str__(), id(other))
 
 
 class BeliefSourceDBMixin(BeliefSource):

--- a/timely_beliefs/tests/test_belief_init.py
+++ b/timely_beliefs/tests/test_belief_init.py
@@ -112,3 +112,57 @@ def test_datetime_parsing(dt, ErrorType, match):
 def test_timedelta_parsing(td, ErrorType, match):
     with pytest.raises(ErrorType, match=match):
         utils.parse_timedelta_like(td)
+
+
+def test_source_ordering_is_a_total_order_for_same_name_sources():
+    """Distinct sources sharing a name must still have a strict total order.
+
+    Regression test for https://github.com/SeitaBV/timely-beliefs/issues/238.
+    """
+    a = BeliefSource("same name")
+    b = BeliefSource("same name")
+    assert (a < b) != (b < a)
+    assert (a > b) != (b > a)
+    assert not (a < b and a > b)
+
+
+def test_concat_frames_with_same_name_sources():
+    """Concatenating frames whose source levels hold distinct sources sharing a
+    name must not map any source to NaN.
+
+    Regression test for https://github.com/SeitaBV/timely-beliefs/issues/238.
+    """
+    from timely_beliefs import BeliefsDataFrame
+
+    sensor = Sensor("total order sensor", event_resolution=timedelta(hours=1))
+    sources = [BeliefSource("s" + str(i % 2 + 1)) for i in range(6)]
+    event_starts = pd.date_range("2025-01-01", periods=5, freq="1h", tz="UTC")
+    belief_times = pd.date_range("2024-12-31", periods=3, freq="1h", tz="UTC")
+    spec = [
+        (4, 1, 0, [0.3, 0.7]),
+        (2, 3, 2, [0.5]),
+        (1, 3, 2, [0.5]),
+        (3, 0, 1, [0.3, 0.7]),
+        (1, 3, 1, [0.5]),
+        (5, 2, 0, [0.5]),
+        (4, 2, 2, [0.3, 0.7]),
+    ]
+    frames = [
+        BeliefsDataFrame(
+            [
+                TimedBelief(
+                    sensor=sensor,
+                    source=sources[s],
+                    event_start=event_starts[e],
+                    belief_time=belief_times[b],
+                    cumulative_probability=cp,
+                    event_value=1.0,
+                )
+                for cp in cps
+            ]
+        )
+        for s, e, b, cps in spec
+    ]
+    bdf = pd.concat(frames)
+    returned_sources = bdf.index.get_level_values("source")
+    assert all(isinstance(source, BeliefSource) for source in returned_sources)


### PR DESCRIPTION
Closes #238.

## What

`BeliefSource.__lt__` compared by string representation only, which is not a strict total order for distinct sources sharing a name: `a < b` and `b < a` are both `False` while `a != b`, and via `@total_ordering`, `a > b` and `b > a` are both `True`.

This let pandas silently corrupt data: operations that sort an object index level and then search it — such as `pd.concat` unioning the `source` level of several BeliefsDataFrames — could map rows to index code `-1`, materializing as **NaN in the source level** in place of a valid source (deterministic 7-frame reproduction in #238; FlexMeasures hit this with multiple versions of a same-named source).

## How

Tie-break the ordering by object identity, which is consistent with the identity-based `__eq__`/`__hash__`:

```python
return (self.__str__(), id(self)) < (other.__str__(), id(other))
```

Ordering among differently-named sources is unchanged; only previously-ill-defined comparisons between same-name sources become deterministic (within a process).

## Verification

- New regression tests: total-order property for same-name sources, and the concat reproduction from #238 (fails on main with 4 NaN sources, passes with the fix).
- Full test suite passes (228 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjAZFQmASY65gPmVtQAahG
