### PR TITLE
Let subclasses choose the type of the value columns

### DIFF
--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -227,7 +227,36 @@ class TimedBeliefDBMixin(TimedBelief):
     """
     Mixin class for a table with beliefs.
     The fields source and sensor do not point to another table - overwrite them to make that happen.
+
+    The SQLAlchemy type of the two per-row numeric value columns (``cumulative_probability``
+    and ``event_value``) can be customized by setting ``value_column_type`` on your subclass.
     """
+
+    #: SQLAlchemy type used to declare the two per-row numeric value columns,
+    #: ``cumulative_probability`` and ``event_value``.
+    #:
+    #: Defaults to :class:`sqlalchemy.Float` (``double precision``/float8 on PostgreSQL,
+    #: 8 bytes per value). Since these are the only per-row numeric columns on what is
+    #: typically by far the largest table, hosts that do not need the full ~15-17
+    #: significant decimal digits of double precision can trade precision for storage by
+    #: setting this to ``Float(precision=24)``, which maps to PostgreSQL ``real``
+    #: (float4, 4 bytes, ~7 significant decimal digits)::
+    #:
+    #:     class MyBelief(Base, TimedBeliefDBMixin):
+    #:         __tablename__ = "my_timed_belief"
+    #:         value_column_type = Float(precision=24)
+    #:
+    #: This only affects how the columns are *declared*. Migrating an existing table is
+    #: up to the host, and narrowing the type is lossy and not reversible: stored values
+    #: are rounded to the nearest representable value. Before narrowing, check that the
+    #: reduced precision is acceptable for the full range of magnitudes you store -- a
+    #: sensor holding cumulative meter readings or currency totals in the millions has
+    #: far less headroom than one holding instantaneous power values.
+    #:
+    #: Note also that PostgreSQL's ``sum()`` over a ``real`` column accumulates in
+    #: ``real``, so aggregate queries over many rows may want to cast to
+    #: ``double precision`` first.
+    value_column_type = Float
 
     @declared_attr
     def __table_args__(cls):
@@ -250,10 +279,20 @@ class TimedBeliefDBMixin(TimedBelief):
 
     event_start = Column(DateTime(timezone=True), primary_key=True, index=True)
     belief_horizon = Column(Interval(), nullable=False, primary_key=True)
-    cumulative_probability = Column(
-        Float, nullable=False, primary_key=True, default=0.5
-    )
-    event_value = Column(Float, nullable=False)
+
+    # Declared via declared_attr (rather than as plain Columns) so that subclasses can
+    # customize their type through value_column_type. Note that this preserves the
+    # column and primary-key ordering that plain Columns produced, whereas redeclaring
+    # these columns in a subclass body would move them to the front of both.
+    @declared_attr
+    def cumulative_probability(cls):
+        return Column(
+            cls.value_column_type, nullable=False, primary_key=True, default=0.5
+        )
+
+    @declared_attr
+    def event_value(cls):
+        return Column(cls.value_column_type, nullable=False)
 
     @declared_attr
     def sensor_id(cls):

--- a/timely_beliefs/docs/db.md
+++ b/timely_beliefs/docs/db.md
@@ -5,6 +5,7 @@
 1. [Derived database classes](#derived-database-classes)
 1. [Table creation and session](#table-creation-and-session)
 1. [Subclassing](#subclassing)
+1. [Value column precision](#value-column-precision)
 1. [Queries](#queries)
 
 ## Derived database classes
@@ -143,6 +144,35 @@ This one uses a Mixin class called `TimedBeliefDBMixin` (which is also used in t
 Note that we don't say where the sqlalchemy `Base` comes from here. This is the one from your project.
 If you create tables from timely_belief's Base (see above) as well, you end up with more tables that you probably want to use.
 Which is not a blocker, but for cleanliness you might want to get all tables from timely beliefs base or define all Table implementations yourself, such as with `JoyfulBeliefInCustomTable` above.
+
+### Value column precision
+
+`cumulative_probability` and `event_value` are the only per-row numeric columns on the beliefs table, which is typically by far the largest table.
+By default both are declared as `Float`, which PostgreSQL stores as `double precision` (float8, 8 bytes per value, ~15-17 significant decimal digits).
+
+If you do not need that much precision, you can trade it for storage by setting `value_column_type` on your subclass.
+`Float(precision=24)` maps to PostgreSQL `real` (float4, 4 bytes, ~7 significant decimal digits), which roughly halves the width of both columns:
+
+    from sqlalchemy import Float
+    from timely_beliefs import TimedBeliefDBMixin
+
+
+    class CompactBelief(Base, TimedBeliefDBMixin):
+
+        __tablename__ = "compact_timed_belief"
+
+        value_column_type = Float(precision=24)
+
+This only changes how the columns are *declared*; migrating an existing table is up to you.
+
+Before narrowing the type, weigh the following:
+
+- **It is lossy and not reversible.** Existing values are rounded to the nearest representable value when you migrate. Widening the column again restores the type, not the digits.
+- **Check your magnitudes, not just your units.** ~7 significant digits is ample for instantaneous power readings, and for a cumulative probability in `[0, 1]`. It is *not* ample for cumulative meter readings or currency totals in the millions, where the gap between representable values grows past 0.1.
+- **Migrating is expensive.** `ALTER COLUMN ... TYPE` rewrites the whole table, and rebuilds the primary key because `cumulative_probability` is part of it. On a large beliefs table, plan a maintenance window.
+- **`sum()` accumulates in the column's own type.** PostgreSQL's `sum(real)` returns `real` and accumulates in `real`, so a sum over many rows can drift noticeably. Cast to `double precision` inside aggregate queries: `sum(event_value::double precision)`. (`avg(real)` already accumulates in double precision, and `min`/`max` are unaffected.)
+
+Note that `BeliefsDataFrame` always holds these values as float64 regardless of the column type, so this setting does not change any in-memory dtypes.
 
 ### Queries
 

--- a/timely_beliefs/tests/test_db_value_column_type.py
+++ b/timely_beliefs/tests/test_db_value_column_type.py
@@ -1,0 +1,73 @@
+"""Tests for customizing the type of the per-row numeric value columns.
+
+These build throwaway declarative classes and only inspect the resulting table
+metadata, so they need no database.
+"""
+
+from sqlalchemy import Column, Float, ForeignKey, Integer
+from sqlalchemy.orm import declarative_base, declared_attr
+
+from timely_beliefs.beliefs.classes import TimedBeliefDBMixin
+
+VALUE_COLUMNS = ("cumulative_probability", "event_value")
+
+
+def build_belief_class(tablename: str, value_column_type=None):
+    """Build a TimedBeliefDBMixin subclass on its own declarative base."""
+    Base = declarative_base()
+    namespace = {"__tablename__": tablename}
+
+    def source_id(cls):
+        return Column(Integer, ForeignKey("belief_source.id"), primary_key=True)
+
+    namespace["source_id"] = declared_attr(source_id)
+    if value_column_type is not None:
+        namespace["value_column_type"] = value_column_type
+    return type(tablename, (Base, TimedBeliefDBMixin), namespace)
+
+
+def test_value_columns_default_to_double_precision():
+    """By default the value columns are float8, i.e. Float without a precision."""
+    cls = build_belief_class("default_belief")
+    for column_name in VALUE_COLUMNS:
+        column = cls.__table__.columns[column_name]
+        assert isinstance(column.type, Float)
+        assert column.type.precision is None
+        assert column.nullable is False
+    assert cls.__table__.columns["cumulative_probability"].primary_key is True
+    assert cls.__table__.columns["event_value"].primary_key is False
+
+
+def test_value_column_type_is_customizable():
+    """Setting value_column_type narrows both value columns to float4."""
+    cls = build_belief_class("float4_belief", value_column_type=Float(precision=24))
+    for column_name in VALUE_COLUMNS:
+        column = cls.__table__.columns[column_name]
+        assert isinstance(column.type, Float)
+        assert column.type.precision == 24
+        # Narrowing the type must not silently drop the other column properties
+        assert column.nullable is False
+    assert cls.__table__.columns["cumulative_probability"].primary_key is True
+    assert cls.__table__.columns["cumulative_probability"].default.arg == 0.5
+    assert cls.__table__.columns["event_value"].primary_key is False
+
+
+def test_customizing_value_column_type_preserves_column_and_pk_order():
+    """Column and primary-key order must not depend on value_column_type.
+
+    Reordering the primary key would silently change index behaviour for hosts
+    that adopt a narrower type, and would make a fresh create_all() disagree with
+    an existing migrated table. Redeclaring these columns in the subclass body
+    (rather than using this hook) does exactly that, which is why the hook exists.
+    """
+    default_cls = build_belief_class("order_default_belief")
+    float4_cls = build_belief_class(
+        "order_float4_belief", value_column_type=Float(precision=24)
+    )
+
+    assert [c.name for c in default_cls.__table__.columns] == [
+        c.name for c in float4_cls.__table__.columns
+    ]
+    assert [c.name for c in default_cls.__table__.primary_key.columns] == [
+        c.name for c in float4_cls.__table__.primary_key.columns
+    ]


### PR DESCRIPTION
## What

Adds a `value_column_type` hook on `TimedBeliefDBMixin` so a host application can choose the SQLAlchemy type of the two per-row numeric value columns, `cumulative_probability` and `event_value`.

The default is unchanged (`Float`, i.e. `double precision`/float8 on PostgreSQL), so existing hosts see no difference in behaviour or DDL.

## Why

These two are the only per-row numeric columns on the beliefs table, which for most hosts is by far the largest table. Storing them as `real` (float4, 4 bytes, ~7 significant decimal digits) instead of `double precision` (float8, 8 bytes) halves their width, shrinking the table on disk by roughly 15-20%.

Whether that trade is acceptable is a deployment-specific call — ~7 significant digits is ample for instantaneous power readings but not for cumulative meter readings in the millions — so this is opt-in rather than a change of default.

Downstream, FlexMeasures wants exactly this (FlexMeasures/flexmeasures#2331, FlexMeasures/flexmeasures#2332).

## Why a hook, and not "just override the columns in your subclass"

That was the original approach in the FlexMeasures PR, and it has a non-obvious problem: **mixin columns are ordered by creation order**, so redeclaring these two columns in a subclass body moves them to the front of the table *and* of the primary key.

Measured on the actual mixin:

| | primary key column order |
|---|---|
| today (plain `Column`s) | `source_id, event_start, belief_horizon, cumulative_probability, sensor_id` |
| subclass-body override | `cumulative_probability, source_id, event_start, belief_horizon, sensor_id` |
| **this hook** | `source_id, event_start, belief_horizon, cumulative_probability, sensor_id` |

The override makes the near-constant `cumulative_probability` (almost always `0.5`) the leading primary-key column — the worst available ordering — and makes a fresh `create_all()` disagree with any existing migrated table. Declaring the columns via `declared_attr` keeps column and primary-key order byte-identical to today, for the default type and a narrowed one alike.

There is a second, quieter reason to put this upstream: a subclass-body override silently discards whatever this library declares on those columns. If `timely_beliefs` later adds a `server_default`, a check constraint or an index there, the host drops it with no error and no failing test.

## Changes

- `beliefs/classes.py`: add `value_column_type` (default `Float`); declare `cumulative_probability` and `event_value` via `declared_attr` so subclasses can customize the type. Documented inline, including the `sum(real)` caveat.
- `tests/test_db_value_column_type.py`: new, DB-free — asserts the default stays float8, that the hook narrows both columns while preserving `nullable`/`primary_key`/`default=0.5`, and that column and primary-key order do not depend on the type.
- `docs/db.md`: new "Value column precision" section covering the trade-offs.

## Caveats a host should read before narrowing

Spelled out in `docs/db.md`:

- Narrowing is **lossy and not reversible** — existing values are rounded on migration; widening again restores the type, not the digits.
- **Magnitudes matter more than units.** Cumulative meter readings or currency totals in the millions have far less headroom than instantaneous power values.
- `ALTER COLUMN ... TYPE` **rewrites the whole table** and rebuilds the primary key (since `cumulative_probability` is part of it) — plan a maintenance window.
- PostgreSQL's **`sum(real)` accumulates in `real`**, so aggregates over many rows can drift; cast to `double precision` inside aggregate queries. (`avg(real)` already accumulates in double precision; `min`/`max` are unaffected.)

`BeliefsDataFrame` holds these values as float64 regardless, so no in-memory dtypes change.

## Testing

Full suite against PostgreSQL 15: **228 passed**. The one failure in `test_viz__plotting.py::test_chart_creation` is pre-existing on `main` in my environment (an Altair version deprecation) and unrelated — verified by running it on a clean checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
