### PR TITLE
Remove scipy and properscoring dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,11 @@ classifiers = [
 ]
 dependencies = [
     "importlib_metadata",
+    "packaging",
     "pytz",
     "isodate",
     # https://github.com/SeitaBV/timely-beliefs/issues/234
     "openturns>=1.23",
-    "properscoring",
 
     # Database support
     "psycopg2-binary",
@@ -54,10 +54,6 @@ dependencies = [
     "pandas >= 1.1.5, < 1.3; python_version == '3.7'",
     # https://github.com/SeitaBV/timely-beliefs/issues/148
     "pandas >= 1.4.0, != 2.1.0, !=2.1.1, < 3; python_version > '3.7'",
-    # scipy's setup requires minimal Python versions
-    "scipy<1.6; python_version <= '3.6'",
-    "scipy<1.8; python_version <= '3.7'",
-    "scipy; python_version > '3.7'",
 ]
 dynamic = ["version"]
 

--- a/timely_beliefs/beliefs/crps.py
+++ b/timely_beliefs/beliefs/crps.py
@@ -1,0 +1,121 @@
+"""Continuous ranked probability score (CRPS) for ensemble forecasts.
+
+Vendored (and trimmed to the single function actually used by timely-beliefs)
+from properscoring 0.1, Copyright 2015 The Climate Corporation, licensed under
+the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0).
+Source files (pinned to the v0.1 tag, matching the PyPI 0.1 wheel):
+- https://github.com/TheClimateCorporation/properscoring/blob/397f97020ea6c06621f9563fbcecfa31ffccc8d7/properscoring/_crps.py
+- https://github.com/TheClimateCorporation/properscoring/blob/397f97020ea6c06621f9563fbcecfa31ffccc8d7/properscoring/_utils.py
+
+Vendored to reduce the number of (transitive) dependencies.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import warnings
+
+import numpy as np
+
+
+def _move_axis_to_end(array: np.ndarray, axis: int) -> np.ndarray:
+    array = np.asarray(array)
+    return np.rollaxis(array, axis, start=array.ndim)
+
+
+def _argsort_indices(a: np.ndarray, axis: int = -1) -> tuple:
+    """Like argsort, but returns an index suitable for sorting the original
+    array even if that array is multidimensional."""
+    a = np.asarray(a)
+    ind = list(np.ix_(*[np.arange(d) for d in a.shape]))
+    ind[axis] = a.argsort(axis)
+    return tuple(ind)
+
+
+@contextlib.contextmanager
+def _suppress_warnings(msg: str | None = None):
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", msg)
+        yield
+
+
+def _crps_ensemble_vectorized(observations, forecasts, weights=1):
+    """CRPS via the identity CRPS(F, x) = E_F|X - x| - 1/2 * E_F|X - X'|,
+    where X and X' are independent random variables drawn from the forecast
+    distribution F. Runtime O(n^2) in the ensemble size, but needs only numpy.
+    """
+    observations = np.asarray(observations)
+    forecasts = np.asarray(forecasts)
+    weights = np.asarray(weights)
+    if weights.ndim > 0:
+        weights = np.where(~np.isnan(forecasts), weights, np.nan)
+        weights = weights / np.nanmean(weights, axis=-1, keepdims=True)
+
+    if observations.ndim == forecasts.ndim - 1:
+        # sum over the last (ensemble) axis
+        assert observations.shape == forecasts.shape[:-1]
+        observations = observations[..., np.newaxis]
+        with _suppress_warnings("Mean of empty slice"):
+            score = np.nanmean(weights * abs(forecasts - observations), -1)
+        # insert new axes along last and second to last forecast dimensions so
+        # forecasts_diff expands with the array broadcasting
+        forecasts_diff = np.expand_dims(forecasts, -1) - np.expand_dims(
+            forecasts, -2
+        )
+        weights_matrix = np.expand_dims(weights, -1) * np.expand_dims(
+            weights, -2
+        )
+        with _suppress_warnings("Mean of empty slice"):
+            score += -0.5 * np.nanmean(
+                weights_matrix * abs(forecasts_diff), axis=(-2, -1)
+            )
+        return score
+    elif observations.ndim == forecasts.ndim:
+        # no 'realization' axis to sum over (this is a deterministic forecast)
+        return abs(observations - forecasts)
+
+
+def crps_ensemble(
+    observations, forecasts, weights=None, issorted: bool = False, axis: int = -1
+):
+    """Calculate the continuous ranked probability score (CRPS) for a set of
+    explicit forecast realizations, compared against a scalar observation.
+
+    See properscoring.crps_ensemble for the full docstring; this is a
+    pure-numpy vendored copy of that function's non-numba code path.
+    """
+    observations = np.asarray(observations)
+    forecasts = np.asarray(forecasts)
+    if axis != -1:
+        forecasts = _move_axis_to_end(forecasts, axis)
+
+    if weights is not None:
+        weights = _move_axis_to_end(weights, axis)
+        if weights.shape != forecasts.shape:
+            raise ValueError("forecasts and weights must have the same shape")
+
+    if observations.shape not in [forecasts.shape, forecasts.shape[:-1]]:
+        raise ValueError(
+            "observations and forecasts must have matching shapes or "
+            "matching shapes except along `axis=%s`" % axis
+        )
+
+    if observations.shape == forecasts.shape:
+        if weights is not None:
+            raise ValueError(
+                "cannot supply weights unless you also supply an ensemble forecast"
+            )
+        return abs(observations - forecasts)
+
+    if not issorted:
+        if weights is None:
+            forecasts = np.sort(forecasts, axis=-1)
+        else:
+            idx = _argsort_indices(forecasts, axis=-1)
+            forecasts = forecasts[idx]
+            weights = weights[idx]
+
+    if weights is None:
+        weights = np.ones_like(forecasts)
+
+    return _crps_ensemble_vectorized(observations, forecasts, weights)

--- a/timely_beliefs/beliefs/probabilistic_utils.py
+++ b/timely_beliefs/beliefs/probabilistic_utils.py
@@ -2,17 +2,26 @@ from __future__ import annotations
 
 import math
 from itertools import product
+from statistics import NormalDist
 from typing import Callable
 
 import numpy as np
 import openturns as ot
 import pandas as pd
-import properscoring as ps
 from pandas.core.groupby import DataFrameGroupBy
-from scipy import special
 
 from timely_beliefs import utils as tb_utils
 from timely_beliefs.beliefs import classes  # noqa: F401
+from timely_beliefs.beliefs.crps import crps_ensemble
+
+
+def erfinv(y: float) -> float:
+    """Inverse of the error function.
+
+    erf(z) = 2 * Phi(z * sqrt(2)) - 1, so erfinv(y) = Phi^-1((y + 1) / 2) / sqrt(2),
+    where Phi is the standard normal cdf (whose inverse is stdlib's NormalDist.inv_cdf).
+    """
+    return NormalDist().inv_cdf((y + 1) / 2) / 2**0.5
 
 
 def interpret_complete_cdf(
@@ -50,11 +59,11 @@ def interpret_complete_cdf(
                 x2 = cdf_v[1]
                 y1 = cdf_p[0]
                 y2 = cdf_p[1]
-                mu = (
-                    x1 * special.erfinv(1 - 2 * y2) - x2 * special.erfinv(1 - 2 * y1)
-                ) / (special.erfinv(1 - 2 * y2) - special.erfinv(1 - 2 * y1))
+                mu = (x1 * erfinv(1 - 2 * y2) - x2 * erfinv(1 - 2 * y1)) / (
+                    erfinv(1 - 2 * y2) - erfinv(1 - 2 * y1)
+                )
                 sigma = (2**0.5 * x1 - 2**0.5 * x2) / (
-                    2 * special.erfinv(1 - 2 * y2) - 2 * special.erfinv(1 - 2 * y1)
+                    2 * erfinv(1 - 2 * y2) - 2 * erfinv(1 - 2 * y1)
                 )
                 cdfs.append(ot.Normal(mu, sigma))
             else:
@@ -461,7 +470,7 @@ def calculate_crps(df: "classes.BeliefsDataFrame") -> "classes.BeliefsDataFrame"
 
             # Calculate the continuous ranked profile score for this step (i.e. how well does the forecast describe this possible outcome for the observation)
             crpss.append(
-                ps.crps_ensemble(v_observation, cdf_v_forecast_i, pdf_p_forecast_i)
+                crps_ensemble(v_observation, cdf_v_forecast_i, pdf_p_forecast_i)
             )
 
             # Set the left cp bound for the next step


### PR DESCRIPTION
Replace scipy call with stdlib equivelant, vendor properscoring files. I tried my best to make sure the code is equivelant, but I don't know anything about the maths, so that will have to be validated.

This results in a reduction of the default install size of timely-beliefs (given that scipy is not required otherwise):

**Core install (no extras):**

| | before | after |
|---|---|---|
| total site-packages | **474 MB** | **362 MB** |
| scipy (+`.libs`) | 123 MB | gone |
| properscoring | 104 KB | gone |

Reduction of ~112 MB / ~24% off every default install.