### PR TITLE
fix: retain event_resolution on BeliefsSeries conversion (#220)

### DIFF
--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -961,7 +961,15 @@ class BeliefsSeries(pd.Series):
         return self
 
     def __init__(self, *args, **kwargs):
+        sensor: Sensor | None = kwargs.pop("sensor", None)
+        event_resolution: TimedeltaLike | None = kwargs.pop("event_resolution", None)
         super().__init__(*args, **kwargs)
+        if len(args) > 0 and isinstance(args[0], (BeliefsSeries, BeliefsDataFrame)):
+            if sensor is None:
+                sensor = getattr(args[0], "sensor", None)
+            if event_resolution is None:
+                event_resolution = getattr(args[0], "event_resolution", None)
+        assign_sensor_and_event_resolution(self, sensor, event_resolution)
         return
 
     def __repr__(self):

--- a/timely_beliefs/tests/test_belief_io.py
+++ b/timely_beliefs/tests/test_belief_io.py
@@ -464,17 +464,54 @@ def test_belief_setup_with_timed_beliefs(args, kwargs):
     tb.BeliefsDataFrame()
 
 
-def test_converting_between_data_frame_and_series_retains_metadata():
+@pytest.mark.parametrize(
+    "custom_event_resolution",
+    [None, timedelta(minutes=7, seconds=30), timedelta(hours=1)],
+)
+def test_converting_between_data_frame_and_series_retains_metadata(
+    custom_event_resolution,
+):
     """
     Test whether slicing of a BeliefsDataFrame into a BeliefsSeries retains the metadata.
     Test whether expanding dimensions of a BeliefsSeries into a BeliefsDataFrame retains the metadata.
+    GH 220: Ensure event_resolution is retained even when it differs from sensor.event_resolution.
     """
     example_df = get_example_df()
+    if custom_event_resolution is not None:
+        example_df.event_resolution = custom_event_resolution
     df = example_df
     series = df["event_value"]
-    assert_metadata_is_retained(series, original_df=example_df, is_series=True)
-    df = series.to_frame()
-    assert_metadata_is_retained(df, original_df=example_df)
+    assert_metadata_is_retained(
+        series,
+        original_df=example_df,
+        is_series=True,
+        event_resolution=custom_event_resolution,
+    )
+
+    # Test direct BeliefsSeries constructor
+    series_constructed = tb.BeliefsSeries(series)
+    assert_metadata_is_retained(
+        series_constructed,
+        original_df=example_df,
+        is_series=True,
+        event_resolution=custom_event_resolution,
+    )
+
+    # Test to_frame()
+    df_from_to_frame = series.to_frame()
+    assert_metadata_is_retained(
+        df_from_to_frame,
+        original_df=example_df,
+        event_resolution=custom_event_resolution,
+    )
+
+    # Test BeliefsDataFrame(series)
+    df_from_constructor = tb.BeliefsDataFrame(series)
+    assert_metadata_is_retained(
+        df_from_constructor,
+        original_df=example_df,
+        event_resolution=custom_event_resolution,
+    )
 
 
 def test_dropping_index_levels_retains_metadata():


### PR DESCRIPTION
## Description
Closes #220.

When slicing a `BeliefsDataFrame` into a `BeliefsSeries` or constructing a `BeliefsSeries` directly, `BeliefsSeries.__init__` previously did not extract `sensor` or `event_resolution` kwargs, nor did it propagate `event_resolution` when initialized from a `BeliefsSeries` or `BeliefsDataFrame`. This caused `BeliefsSeries` objects to lose their explicit `event_resolution` when it differed from `sensor.event_resolution`.

## Changes Made
- Updated `BeliefsSeries.__init__` in `timely_beliefs/beliefs/classes.py` to pop `sensor` and `event_resolution` from `kwargs`, inherit them from `args[0]` if `args[0]` is a `BeliefsSeries` or `BeliefsDataFrame`, and assign them via `assign_sensor_and_event_resolution`.
- Extended `test_converting_between_data_frame_and_series_retains_metadata` in `timely_beliefs/tests/test_belief_io.py` with parametrized cases covering `None`, `7m30s`, and `1h` custom resolutions across slicing, direct `BeliefsSeries` construction, `to_frame()`, and `BeliefsDataFrame(series)`.

## Verification
- Ran `pytest --noconftest timely_beliefs/tests/test_belief_io.py` (55 passed).
- Ran all pure unit test suites (103 passed).
- Checked `black` (clean, 2 files left unchanged).
- Checked `isort` (clean).
- Checked `flake8` (0 errors).
