### PR TITLE
ci: run the checks on pull requests, and restore a green main

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,6 +1,16 @@
 name: lint-and-test
 
-on: push
+on:
+  # Pull requests, so that contributions from forks are checked before they are merged.
+  # Forks cannot run these checks themselves, because their own Actions runs never report back to this repository.
+  pull_request:
+  # Pushes to main and to tags only, so that the post-merge and released states stay checked,
+  # without running every branch twice. Branches are already covered by the pull request trigger.
+  push:
+    branches:
+      - main
+    tags:
+      - '**'
 
 
 jobs:

--- a/timely_beliefs/tests/test_source_ordering.py
+++ b/timely_beliefs/tests/test_source_ordering.py
@@ -34,9 +34,9 @@ def test_belief_source_lt_same_name_tiebreaks_on_identity():
     s2 = BeliefSource("same")
 
     # Exactly one must be strictly less than the other.
-    assert (s1 < s2) != (s2 < s1), (
-        "__lt__ must tiebreak on id() so distinct same-name objects are comparable"
-    )
+    assert (s1 < s2) != (
+        s2 < s1
+    ), "__lt__ must tiebreak on id() so distinct same-name objects are comparable"
 
     # They are not equal to each other (identity semantics).
     assert s1 != s2
@@ -64,8 +64,8 @@ def test_belief_source_identity_equality_and_hash():
     s1 = BeliefSource("Source A")
     s2 = BeliefSource("Source A")  # same name, different object
 
-    assert s1 == s1        # same object is equal to itself
-    assert s1 != s2        # different objects, even with the same name
+    assert s1 == s1  # same object is equal to itself
+    assert s1 != s2  # different objects, even with the same name
 
     # Each source is its own unique dict key / set member.
     source_set = {s1, s2}


### PR DESCRIPTION
Pull requests from forks currently run no checks at all in this repository, and `main` is red. This fixes both, so that incoming contributions can actually be judged on their test results.

## Run the checks on pull requests

`lint-and-test.yml` was triggered `on: push` only. A pull request from a fork therefore never ran a single check here: the contributor's fork may run the workflow on its own pushes, but those runs do not report back to this repository. The result is a pull request with no status at all — `gh pr checks` reports "no checks reported on the branch", and the head commit has zero check runs.

This adds the `pull_request` trigger.

To avoid running every branch twice, the `push` trigger is narrowed to `main` at the same time — branches in this repository are covered by the `pull_request` trigger once a pull request is open. Tags stay included, because `release.yml` publishes to PyPI without depending on these checks, so the tag run is the only thing checking a release.

## Restore a green main

The `check` job on `main` has been failing on `black`. `timely_beliefs/tests/test_source_ordering.py` is formatted the way newer black versions want it, rather than the way the pinned `25.1.0` in `.pre-commit-config.yaml` does. Running the pinned hook reformats two asserts.

Worth doing before the trigger change lands: otherwise the newly-enabled pull request checks would immediately go red on every pull request, for a reason that has nothing to do with the pull request.

## Verification

- `pre-commit run --all-files` with the pinned hooks: isort, flake8 and black all pass.
- Full test suite: 234 passed.
- The workflow YAML parses to the intended triggers: `{'pull_request': None, 'push': {'branches': ['main'], 'tags': ['**']}}`.

The trigger change cannot be verified on this pull request itself, since the workflow that runs is the one on `main`. It takes effect for pull requests opened after this merges.

## Context

Found while reviewing #249, which has no CI results for exactly this reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASeQ7rfgERhFFEynjebLGh