### PR TITLE
Write large belief batches with COPY instead of a multi-row INSERT

### DIFF
--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -340,10 +340,16 @@ class TimedBeliefDBMixin(TimedBelief):
         beliefs_data_frame = (
             beliefs_data_frame.convert_index_from_belief_time_to_horizon().reset_index()
         )
-        beliefs = [
-            cls(sensor=beliefs_data_frame.sensor, **d)
-            for d in beliefs_data_frame.to_dict("records")
-        ]
+        if not bulk_save_objects:
+            # Only the ORM path below writes these. The bulk path used to build them
+            # too, which cost more than the write it was feeding: the sensor and source
+            # backrefs pull every one of them into the session, so a batch of 29k
+            # beliefs spent seconds in register_object during the flush, for objects
+            # nothing ever reads.
+            beliefs = [
+                cls(sensor=beliefs_data_frame.sensor, **d)
+                for d in beliefs_data_frame.to_dict("records")
+            ]
 
         if expunge_session:
             session.expunge_all()

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -2685,7 +2685,23 @@ def _copy_frame(
 
 
 def _as_copy_value(value):
-    """Render one value the way PostgreSQL's CSV COPY parser expects it."""
+    """Render one value the way PostgreSQL's CSV COPY parser expects it.
+
+    Called once per cell, which is where most of a batch now goes: about 175,000
+    calls for 29,000 beliefs, and roughly three quarters of the time spent building
+    the payload. That is deliberate, and was measured rather than assumed. Converting
+    column-wise instead and handing the frame to ``DataFrame.to_csv`` renders the same
+    payload about 1.7x faster, but costs two things worth more than the time:
+
+    - ``to_csv``'s ``na_rep`` cannot tell a missing value from a NaN, so a NaN event
+      value would be written as the NULL marker and break on event_value's NOT NULL
+      constraint, which is the regression this function's NaN branch exists to avoid.
+    - ``to_csv`` renders the whole payload as one string, which is what _CsvRows was
+      written to avoid holding for a batch of a million beliefs.
+
+    Both are answerable -- special-case the float columns, chunk the frame -- but only
+    by rebuilding column-wise what this does per value, for a fifth off a batch.
+    """
     if value is None or value is pd.NaT or value is pd.NA:
         # The NULL marker, which is what a bound None was. An empty field is left to
         # mean an empty string, so a nullable text column can hold either.

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -2700,7 +2700,8 @@ def _as_copy_value(value):
       written to avoid holding for a batch of a million beliefs.
 
     Both are answerable -- special-case the float columns, chunk the frame -- but only
-    by rebuilding column-wise what this does per value, for a fifth off a batch.
+    by rebuilding column-wise what this does per value, and the whole batch would come
+    out around 20% faster in return.
     """
     if value is None or value is pd.NaT or value is pd.NA:
         # The NULL marker, which is what a bound None was. An empty field is left to

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -30,7 +30,6 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     Interval,
-    String,
     Table,
     and_,
     cast,
@@ -72,6 +71,9 @@ COPY_THRESHOLD = 200
 # hold a second copy of it in memory, which for a batch of a million beliefs is tens of
 # megabytes that buy nothing.
 _COPY_CHUNK_SIZE = 1 << 20
+
+# What a NULL looks like on the wire. COPY's own text format uses the same marker.
+_COPY_NULL = "\\N"
 
 METADATA = ["sensor", "event_resolution"]
 DatetimeLike = Union[datetime, str, pd.Timestamp]
@@ -454,7 +456,7 @@ class TimedBeliefDBMixin(TimedBelief):
         else:
             target = table.name
 
-        _copy_frame(session, target, columns, beliefs_data_frame, table)
+        _copy_frame(session, target, columns, beliefs_data_frame)
 
         if allow_overwrite:
             session.execute(
@@ -2640,7 +2642,6 @@ def _copy_frame(
     table_name: str,
     columns: list[str],
     frame: pd.DataFrame,
-    table: Table,
 ) -> None:
     """Stream a frame into a PostgreSQL table with COPY, inside the session's transaction.
 
@@ -2652,14 +2653,15 @@ def _copy_frame(
     reader = _CsvRows(frame, columns)
 
     quoted = ", ".join(f'"{c}"' for c in columns)
-    options = "FORMAT csv"
-    # Without this, an empty string in a text column would arrive as NULL, because that
-    # is what an unquoted empty CSV field means. No column of a belief is text, but a
-    # table built on this mixin may well add one.
-    textual = [c for c in columns if isinstance(table.c[c].type, String)]
-    if textual:
-        options += " , FORCE_NOT_NULL (" + ", ".join(f'"{c}"' for c in textual) + ")"
-    statement = f'COPY "{table_name}" ({quoted}) FROM STDIN WITH ({options})'
+    # An explicit NULL marker, rather than CSV's default of an unquoted empty field,
+    # which would make an empty string in a text column indistinguishable from NULL.
+    # No column of a belief is text, but a table built on this mixin may well add one.
+    # A text value that is itself "\\N" would come back as NULL, which is the same
+    # corner COPY's own text format has always had.
+    statement = (
+        f'COPY "{table_name}" ({quoted}) FROM STDIN '
+        f"WITH (FORMAT csv, NULL '{_COPY_NULL}')"
+    )
 
     # Go through session.connection() so the COPY joins the session's transaction and
     # is rolled back with it.
@@ -2685,8 +2687,9 @@ def _copy_frame(
 def _as_copy_value(value):
     """Render one value the way PostgreSQL's CSV COPY parser expects it."""
     if value is None or value is pd.NaT or value is pd.NA:
-        # An unquoted empty field is NULL, which is what a bound None was.
-        return ""
+        # The NULL marker, which is what a bound None was. An empty field is left to
+        # mean an empty string, so a nullable text column can hold either.
+        return _COPY_NULL
     if isinstance(value, float) and math.isnan(value):
         # Not NULL: a bound NaN went into a float column as NaN, and PostgreSQL's float
         # input accepts "NaN", so this path stores what the multi-row INSERT stored.

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -2613,14 +2613,22 @@ def _copy_frame(
 
 def _as_copy_value(value):
     """Render one value the way PostgreSQL's CSV COPY parser expects it."""
-    if value is None or value is pd.NaT:
+    if value is None or value is pd.NaT or value is pd.NA:
+        # An unquoted empty field is NULL, which is what a bound None was.
         return ""
     if isinstance(value, float) and math.isnan(value):
-        return ""
+        # Not NULL: a bound NaN went into a float column as NaN, and PostgreSQL's float
+        # input accepts "NaN", so this path stores what the multi-row INSERT stored.
+        # Leaving the field empty would instead break on a NOT NULL column such as
+        # event_value.
+        return "NaN"
     if isinstance(value, (pd.Timedelta, timedelta)):
         # An interval literal, rather than str(timedelta), whose "1 day, 2:00:00" form
-        # PostgreSQL does not accept. Seconds also keep negative horizons intact.
-        return f"{value.total_seconds()} seconds"
+        # PostgreSQL does not accept. Whole microseconds, rather than total_seconds(),
+        # whose float repr turns into exponent notation below 1e-4 ("1.5e-05 seconds"),
+        # which the interval parser rejects. Integer division keeps negative horizons
+        # intact, and microseconds are the resolution an interval column stores anyway.
+        return f"{value // timedelta(microseconds=1)} microseconds"
     if isinstance(value, (pd.Timestamp, datetime)):
         return value.isoformat()
     return value

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -439,19 +439,18 @@ class TimedBeliefDBMixin(TimedBelief):
 
         if allow_overwrite:
             # A temporary table, because COPY has no ON CONFLICT clause of its own.
-            # One per connection, kept across batches: creating and dropping it per
-            # batch left a dozen dead pg_attribute rows behind each time, and cost two
-            # round trips that the upsert path can do without. It empties itself at
-            # commit, and is emptied again here, because two calls within one
-            # transaction would otherwise let the first batch's rows through twice.
+            # Created and dropped per batch: keeping one per connection saves no round
+            # trip (both shapes are four statements) and only avoids some catalog
+            # churn, in exchange for a definition that outlives the transaction on a
+            # pooled connection and goes stale if a migration renames or drops one of
+            # the columns written here.
             staging = f"tb_copy_{table.name}"
             session.execute(
                 text(
-                    f'CREATE TEMPORARY TABLE IF NOT EXISTS "{staging}" '
-                    f'(LIKE "{table.name}" INCLUDING DEFAULTS) ON COMMIT DELETE ROWS'
+                    f'CREATE TEMPORARY TABLE "{staging}" '
+                    f'(LIKE "{table.name}" INCLUDING DEFAULTS) ON COMMIT DROP'
                 )
             )
-            session.execute(text(f'TRUNCATE "{staging}"'))
             target = staging
         else:
             target = table.name
@@ -468,6 +467,7 @@ class TimedBeliefDBMixin(TimedBelief):
                     "DO UPDATE SET event_value = EXCLUDED.event_value"
                 )
             )
+            session.execute(text(f'DROP TABLE "{staging}"'))
 
     @classmethod
     def search_session(  # noqa: C901

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -8,6 +8,7 @@ import operator
 import types
 from datetime import datetime, timedelta
 from functools import partial
+from itertools import islice
 from typing import TYPE_CHECKING, Any, Callable, Literal, Type, Union
 
 from packaging import version
@@ -29,6 +30,7 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     Interval,
+    String,
     Table,
     and_,
     cast,
@@ -65,6 +67,11 @@ logger = logging.getLogger(__name__)
 # Below this many beliefs, a multi-row INSERT is not worth replacing: COPY only starts
 # to pay once the client-side cost of binding one parameter per value dominates.
 COPY_THRESHOLD = 200
+
+# How much CSV to hand the driver at a time. Rendering the whole frame up front would
+# hold a second copy of it in memory, which for a batch of a million beliefs is tens of
+# megabytes that buy nothing.
+_COPY_CHUNK_SIZE = 1 << 20
 
 METADATA = ["sensor", "event_resolution"]
 DatetimeLike = Union[datetime, str, pd.Timestamp]
@@ -375,7 +382,7 @@ class TimedBeliefDBMixin(TimedBelief):
             beliefs_data_frame["sensor_id"] = beliefs_data_frame.sensor.id
             beliefs_data_frame = beliefs_data_frame.drop(columns=["source"])
 
-            if _should_copy(session, len(beliefs_data_frame)):
+            if _should_copy(session, cls.__table__, beliefs_data_frame):
                 cls._copy_to_session(session, beliefs_data_frame, allow_overwrite)
             else:
                 smt = insert(cls).values(beliefs_data_frame.to_dict("records"))
@@ -430,18 +437,24 @@ class TimedBeliefDBMixin(TimedBelief):
 
         if allow_overwrite:
             # A temporary table, because COPY has no ON CONFLICT clause of its own.
+            # One per connection, kept across batches: creating and dropping it per
+            # batch left a dozen dead pg_attribute rows behind each time, and cost two
+            # round trips that the upsert path can do without. It empties itself at
+            # commit, and is emptied again here, because two calls within one
+            # transaction would otherwise let the first batch's rows through twice.
             staging = f"tb_copy_{table.name}"
             session.execute(
                 text(
-                    f'CREATE TEMPORARY TABLE "{staging}" '
-                    f'(LIKE "{table.name}" INCLUDING DEFAULTS) ON COMMIT DROP'
+                    f'CREATE TEMPORARY TABLE IF NOT EXISTS "{staging}" '
+                    f'(LIKE "{table.name}" INCLUDING DEFAULTS) ON COMMIT DELETE ROWS'
                 )
             )
+            session.execute(text(f'TRUNCATE "{staging}"'))
             target = staging
         else:
             target = table.name
 
-        _copy_frame(session, target, columns, beliefs_data_frame)
+        _copy_frame(session, target, columns, beliefs_data_frame, table)
 
         if allow_overwrite:
             session.execute(
@@ -453,7 +466,6 @@ class TimedBeliefDBMixin(TimedBelief):
                     "DO UPDATE SET event_value = EXCLUDED.event_value"
                 )
             )
-            session.execute(text(f'DROP TABLE "{staging}"'))
 
     @classmethod
     def search_session(  # noqa: C901
@@ -2567,19 +2579,68 @@ def downsample_beliefs_data_frame(
     return df
 
 
-def _should_copy(session: Session, n_rows: int) -> bool:
+def _should_copy(session: Session, table: Table, frame: pd.DataFrame) -> bool:
     """Whether this batch of beliefs is worth streaming with COPY.
 
     COPY is PostgreSQL-only, so any other backend keeps the multi-row INSERT.
     """
-    if n_rows < COPY_THRESHOLD:
+    if len(frame) < COPY_THRESHOLD:
         return False
     bind = session.get_bind()
-    return bool(bind is not None and bind.dialect.name == "postgresql")
+    if bind is None or bind.dialect.name != "postgresql":
+        return False
+    # A column the frame leaves out falls back to the table's own DEFAULT under COPY,
+    # and a default declared in Python (as cumulative_probability's 0.5 is) never
+    # reaches the table. INSERT fills those in itself, so let it.
+    return not any(
+        column.default is not None and column.name not in frame.columns
+        for column in table.columns
+    )
+
+
+class _CsvRows(io.TextIOBase):
+    """The frame's rows as CSV, rendered while the driver reads them.
+
+    Only ``read`` is used: psycopg2's ``copy_expert`` pulls from it, and the psycopg 3
+    branch pushes what it returns.
+    """
+
+    def __init__(self, frame: pd.DataFrame, columns: list[str]):
+        self._rows = frame[columns].itertuples(index=False, name=None)
+        self._buffer = io.StringIO()
+        self._writer = csv.writer(self._buffer, lineterminator="\n")
+        self._pending = ""
+
+    def readable(self) -> bool:
+        return True
+
+    def read(self, size: int | None = -1) -> str:
+        while size is None or size < 0 or len(self._pending) < size:
+            self._buffer.seek(0)
+            self._buffer.truncate(0)
+            rows = list(islice(self._rows, 1000))
+            if not rows:
+                break
+            self._writer.writerows(
+                [_as_copy_value(value) for value in row] for row in rows
+            )
+            self._pending += self._buffer.getvalue()
+        if size is None or size < 0:
+            chunk, self._pending = self._pending, ""
+            return chunk
+        chunk, self._pending = self._pending[:size], self._pending[size:]
+        return chunk
+
+    def readline(self, size: int | None = -1) -> str:  # pragma: no cover
+        raise io.UnsupportedOperation("_CsvRows is read-in-chunks only")
 
 
 def _copy_frame(
-    session: Session, table_name: str, columns: list[str], frame: pd.DataFrame
+    session: Session,
+    table_name: str,
+    columns: list[str],
+    frame: pd.DataFrame,
+    table: Table,
 ) -> None:
     """Stream a frame into a PostgreSQL table with COPY, inside the session's transaction.
 
@@ -2588,14 +2649,17 @@ def _copy_frame(
     tends to get wrong on exactly the values that are rare enough not to show up in
     testing.
     """
-    buffer = io.StringIO()
-    writer = csv.writer(buffer, lineterminator="\n")
-    for row in frame[columns].itertuples(index=False, name=None):
-        writer.writerow([_as_copy_value(value) for value in row])
-    buffer.seek(0)
+    reader = _CsvRows(frame, columns)
 
     quoted = ", ".join(f'"{c}"' for c in columns)
-    statement = f'COPY "{table_name}" ({quoted}) FROM STDIN WITH (FORMAT csv)'
+    options = "FORMAT csv"
+    # Without this, an empty string in a text column would arrive as NULL, because that
+    # is what an unquoted empty CSV field means. No column of a belief is text, but a
+    # table built on this mixin may well add one.
+    textual = [c for c in columns if isinstance(table.c[c].type, String)]
+    if textual:
+        options += " , FORCE_NOT_NULL (" + ", ".join(f'"{c}"' for c in textual) + ")"
+    statement = f'COPY "{table_name}" ({quoted}) FROM STDIN WITH ({options})'
 
     # Go through session.connection() so the COPY joins the session's transaction and
     # is rolled back with it.
@@ -2604,10 +2668,11 @@ def _copy_frame(
     try:
         with connection.connection.driver_connection.cursor() as cursor:
             if hasattr(cursor, "copy_expert"):  # psycopg2
-                cursor.copy_expert(statement, buffer)
+                cursor.copy_expert(statement, reader)
             else:  # psycopg 3
                 with cursor.copy(statement) as copy:
-                    copy.write(buffer.read())
+                    while chunk := reader.read(_COPY_CHUNK_SIZE):
+                        copy.write(chunk)
     except dialect.dbapi.Error as error:
         # Driving the cursor directly means SQLAlchemy never sees the failure, so a
         # unique violation would surface as a raw psycopg error rather than as

--- a/timely_beliefs/beliefs/classes.py
+++ b/timely_beliefs/beliefs/classes.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import csv
+import io
 import logging
 import math
 import operator
@@ -32,9 +34,11 @@ from sqlalchemy import (
     cast,
     func,
     select,
+    text,
     union_all,
 )
 from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
 from sqlalchemy.orm import Session, backref, declarative_mixin, relationship
@@ -57,6 +61,10 @@ from timely_beliefs.sources import utils as source_utils
 from timely_beliefs.sources.classes import BeliefSource, DBBeliefSource
 
 logger = logging.getLogger(__name__)
+
+# Below this many beliefs, a multi-row INSERT is not worth replacing: COPY only starts
+# to pay once the client-side cost of binding one parameter per value dominates.
+COPY_THRESHOLD = 200
 
 METADATA = ["sensor", "event_resolution"]
 DatetimeLike = Union[datetime, str, pd.Timestamp]
@@ -361,21 +369,24 @@ class TimedBeliefDBMixin(TimedBelief):
             beliefs_data_frame["sensor_id"] = beliefs_data_frame.sensor.id
             beliefs_data_frame = beliefs_data_frame.drop(columns=["source"])
 
-            smt = insert(cls).values(beliefs_data_frame.to_dict("records"))
+            if _should_copy(session, len(beliefs_data_frame)):
+                cls._copy_to_session(session, beliefs_data_frame, allow_overwrite)
+            else:
+                smt = insert(cls).values(beliefs_data_frame.to_dict("records"))
 
-            if allow_overwrite:
-                smt = smt.on_conflict_do_update(
-                    index_elements=[
-                        "event_start",
-                        "belief_horizon",
-                        "source_id",
-                        "sensor_id",
-                        "cumulative_probability",
-                    ],
-                    set_=dict(event_value=smt.excluded.event_value),
-                )
+                if allow_overwrite:
+                    smt = smt.on_conflict_do_update(
+                        index_elements=[
+                            "event_start",
+                            "belief_horizon",
+                            "source_id",
+                            "sensor_id",
+                            "cumulative_probability",
+                        ],
+                        set_=dict(event_value=smt.excluded.event_value),
+                    )
 
-            session.execute(smt)
+                session.execute(smt)
 
         else:
             if allow_overwrite:
@@ -386,6 +397,57 @@ class TimedBeliefDBMixin(TimedBelief):
 
         if commit_transaction:
             session.commit()
+
+    @classmethod
+    def _copy_to_session(
+        cls,
+        session: Session,
+        beliefs_data_frame: pd.DataFrame,
+        allow_overwrite: bool,
+    ):
+        """Write beliefs with PostgreSQL's COPY rather than a multi-row INSERT.
+
+        A multi-row ``INSERT ... VALUES`` has to bind one parameter per value, so a
+        frame of tens of thousands of beliefs is compiled into hundreds of thousands of
+        bound parameters before the server sees anything. COPY streams the same rows as
+        text, which is roughly an order of magnitude less work on the client and rather
+        less on the server too.
+
+        Without ``allow_overwrite`` the rows go straight into the table, so a conflict
+        raises just as it would have. With ``allow_overwrite`` they go into a temporary
+        table first, and a single INSERT ... SELECT carries the upsert. Duplicate keys
+        within one call still raise, which is what the multi-row INSERT did as well.
+        """
+        columns = list(beliefs_data_frame.columns)
+        table = cls.__table__
+        quoted = ", ".join(f'"{c}"' for c in columns)
+
+        if allow_overwrite:
+            # A temporary table, because COPY has no ON CONFLICT clause of its own.
+            staging = f"tb_copy_{table.name}"
+            session.execute(
+                text(
+                    f'CREATE TEMPORARY TABLE "{staging}" '
+                    f'(LIKE "{table.name}" INCLUDING DEFAULTS) ON COMMIT DROP'
+                )
+            )
+            target = staging
+        else:
+            target = table.name
+
+        _copy_frame(session, target, columns, beliefs_data_frame)
+
+        if allow_overwrite:
+            session.execute(
+                text(
+                    f'INSERT INTO "{table.name}" ({quoted}) '
+                    f'SELECT {quoted} FROM "{staging}" '
+                    "ON CONFLICT (event_start, belief_horizon, source_id, sensor_id, "
+                    "cumulative_probability) "
+                    "DO UPDATE SET event_value = EXCLUDED.event_value"
+                )
+            )
+            session.execute(text(f'DROP TABLE "{staging}"'))
 
     @classmethod
     def search_session(  # noqa: C901
@@ -2497,3 +2559,68 @@ def downsample_beliefs_data_frame(
     ).set_index([belief_timing_col, "source", "cumulative_probability"], append=True)
     df.event_resolution = event_resolution
     return df
+
+
+def _should_copy(session: Session, n_rows: int) -> bool:
+    """Whether this batch of beliefs is worth streaming with COPY.
+
+    COPY is PostgreSQL-only, so any other backend keeps the multi-row INSERT.
+    """
+    if n_rows < COPY_THRESHOLD:
+        return False
+    bind = session.get_bind()
+    return bool(bind is not None and bind.dialect.name == "postgresql")
+
+
+def _copy_frame(
+    session: Session, table_name: str, columns: list[str], frame: pd.DataFrame
+) -> None:
+    """Stream a frame into a PostgreSQL table with COPY, inside the session's transaction.
+
+    The rows are written as CSV: PostgreSQL reads an unquoted empty field as NULL, and
+    the csv module handles quoting and escaping, which hand-rolled text formatting
+    tends to get wrong on exactly the values that are rare enough not to show up in
+    testing.
+    """
+    buffer = io.StringIO()
+    writer = csv.writer(buffer, lineterminator="\n")
+    for row in frame[columns].itertuples(index=False, name=None):
+        writer.writerow([_as_copy_value(value) for value in row])
+    buffer.seek(0)
+
+    quoted = ", ".join(f'"{c}"' for c in columns)
+    statement = f'COPY "{table_name}" ({quoted}) FROM STDIN WITH (FORMAT csv)'
+
+    # Go through session.connection() so the COPY joins the session's transaction and
+    # is rolled back with it.
+    connection = session.connection()
+    dialect = connection.dialect
+    try:
+        with connection.connection.driver_connection.cursor() as cursor:
+            if hasattr(cursor, "copy_expert"):  # psycopg2
+                cursor.copy_expert(statement, buffer)
+            else:  # psycopg 3
+                with cursor.copy(statement) as copy:
+                    copy.write(buffer.read())
+    except dialect.dbapi.Error as error:
+        # Driving the cursor directly means SQLAlchemy never sees the failure, so a
+        # unique violation would surface as a raw psycopg error rather than as
+        # IntegrityError. Wrap it the way an ordinary execute would have.
+        raise DBAPIError.instance(
+            statement, None, error, dialect.dbapi.Error, dialect=dialect
+        ) from error
+
+
+def _as_copy_value(value):
+    """Render one value the way PostgreSQL's CSV COPY parser expects it."""
+    if value is None or value is pd.NaT:
+        return ""
+    if isinstance(value, float) and math.isnan(value):
+        return ""
+    if isinstance(value, (pd.Timedelta, timedelta)):
+        # An interval literal, rather than str(timedelta), whose "1 day, 2:00:00" form
+        # PostgreSQL does not accept. Seconds also keep negative horizons intact.
+        return f"{value.total_seconds()} seconds"
+    if isinstance(value, (pd.Timestamp, datetime)):
+        return value.isoformat()
+    return value

--- a/timely_beliefs/tests/test_belief_copy.py
+++ b/timely_beliefs/tests/test_belief_copy.py
@@ -28,7 +28,9 @@ def frame_of(sensor, source, n=N, offset=0.0, belief_horizon=timedelta(0)):
         name="event_start",
     )
     return BeliefsDataFrame(
-        pd.Series([float(i) + offset for i in range(n)], index=index, name="event_value"),
+        pd.Series(
+            [float(i) + offset for i in range(n)], index=index, name="event_value"
+        ),
         belief_horizon=belief_horizon,
         sensor=sensor,
         source=source,
@@ -47,7 +49,9 @@ def test_copy_path_is_taken(time_slot_sensor, test_source_a):
 
 
 @pytest.mark.parametrize("allow_overwrite", [False, True])
-def test_copy_matches_insert(time_slot_sensor, test_source_a, test_source_b, allow_overwrite):
+def test_copy_matches_insert(
+    time_slot_sensor, test_source_a, test_source_b, allow_overwrite
+):
     """The same beliefs written via COPY and via the multi-row INSERT come back equal."""
     via_copy = frame_of(time_slot_sensor, test_source_a)
     DBTimedBelief.add_to_session(
@@ -60,7 +64,10 @@ def test_copy_matches_insert(time_slot_sensor, test_source_a, test_source_b, all
     try:
         via_insert = frame_of(time_slot_sensor, test_source_b)
         DBTimedBelief.add_to_session(
-            session, via_insert, allow_overwrite=allow_overwrite, commit_transaction=True
+            session,
+            via_insert,
+            allow_overwrite=allow_overwrite,
+            commit_transaction=True,
         )
     finally:
         classes.COPY_THRESHOLD = original

--- a/timely_beliefs/tests/test_belief_copy.py
+++ b/timely_beliefs/tests/test_belief_copy.py
@@ -1,0 +1,126 @@
+"""The COPY path must write exactly what the multi-row INSERT wrote.
+
+`add_to_session` streams large batches of beliefs with PostgreSQL's COPY instead of
+binding one parameter per value. These tests drive batches over COPY_THRESHOLD, so they
+take that path, and compare against the same beliefs written the old way.
+"""
+
+from datetime import datetime, timedelta
+
+import pandas as pd
+import pytest
+import pytz
+from sqlalchemy.exc import IntegrityError
+
+from timely_beliefs import BeliefsDataFrame, DBTimedBelief
+from timely_beliefs.beliefs import classes
+from timely_beliefs.tests import session
+
+N = classes.COPY_THRESHOLD + 50  # comfortably over the threshold
+
+
+def frame_of(sensor, source, n=N, offset=0.0, belief_horizon=timedelta(0)):
+    """A frame of `n` beliefs about consecutive events, one belief each."""
+    index = pd.date_range(
+        datetime(2000, 1, 3, 9, tzinfo=pytz.utc),
+        periods=n,
+        freq=sensor.event_resolution,
+        name="event_start",
+    )
+    return BeliefsDataFrame(
+        pd.Series([float(i) + offset for i in range(n)], index=index, name="event_value"),
+        belief_horizon=belief_horizon,
+        sensor=sensor,
+        source=source,
+    )
+
+
+def read_back(sensor, source):
+    bdf = DBTimedBelief.search_session(session=session, sensor=sensor, source=source)
+    return bdf.reset_index().sort_values("event_start").reset_index(drop=True)
+
+
+def test_copy_path_is_taken(time_slot_sensor, test_source_a):
+    """A batch over the threshold goes through COPY; a small one does not."""
+    assert classes._should_copy(session, N) is True
+    assert classes._should_copy(session, classes.COPY_THRESHOLD - 1) is False
+
+
+@pytest.mark.parametrize("allow_overwrite", [False, True])
+def test_copy_matches_insert(time_slot_sensor, test_source_a, test_source_b, allow_overwrite):
+    """The same beliefs written via COPY and via the multi-row INSERT come back equal."""
+    via_copy = frame_of(time_slot_sensor, test_source_a)
+    DBTimedBelief.add_to_session(
+        session, via_copy, allow_overwrite=allow_overwrite, commit_transaction=True
+    )
+
+    # Force the INSERT path for the second source, by raising the threshold.
+    original = classes.COPY_THRESHOLD
+    classes.COPY_THRESHOLD = N + 1
+    try:
+        via_insert = frame_of(time_slot_sensor, test_source_b)
+        DBTimedBelief.add_to_session(
+            session, via_insert, allow_overwrite=allow_overwrite, commit_transaction=True
+        )
+    finally:
+        classes.COPY_THRESHOLD = original
+
+    copied = read_back(time_slot_sensor, test_source_a)
+    inserted = read_back(time_slot_sensor, test_source_b)
+
+    assert len(copied) == N
+    assert len(inserted) == N
+    pd.testing.assert_series_equal(
+        copied["event_value"], inserted["event_value"], check_names=False
+    )
+    pd.testing.assert_series_equal(
+        copied["event_start"], inserted["event_start"], check_names=False
+    )
+    pd.testing.assert_series_equal(
+        copied["belief_time"], inserted["belief_time"], check_names=False
+    )
+
+
+def test_copy_upsert_overwrites(time_slot_sensor, test_source_a):
+    """With allow_overwrite, a second COPY of the same events updates their values."""
+    DBTimedBelief.add_to_session(
+        session, frame_of(time_slot_sensor, test_source_a), commit_transaction=True
+    )
+    DBTimedBelief.add_to_session(
+        session,
+        frame_of(time_slot_sensor, test_source_a, offset=1000.0),
+        allow_overwrite=True,
+        commit_transaction=True,
+    )
+    got = read_back(time_slot_sensor, test_source_a)
+    assert len(got) == N, "upsert should update rows, not add them"
+    assert got["event_value"].iloc[0] == 1000.0
+    assert got["event_value"].iloc[-1] == float(N - 1) + 1000.0
+
+
+def test_copy_without_overwrite_still_conflicts(time_slot_sensor, test_source_a):
+    """Without allow_overwrite, a duplicate raises, exactly as the INSERT path did."""
+    DBTimedBelief.add_to_session(
+        session, frame_of(time_slot_sensor, test_source_a), commit_transaction=True
+    )
+    with pytest.raises(IntegrityError):
+        DBTimedBelief.add_to_session(
+            session,
+            frame_of(time_slot_sensor, test_source_a, offset=1.0),
+            commit_transaction=True,
+        )
+    session.rollback()
+
+
+def test_copy_handles_negative_and_fractional_horizons(time_slot_sensor, test_source_a):
+    """Belief horizons are written as intervals, including negative ones."""
+    horizon = timedelta(seconds=-1.5)
+    DBTimedBelief.add_to_session(
+        session,
+        frame_of(time_slot_sensor, test_source_a, belief_horizon=horizon),
+        commit_transaction=True,
+    )
+    got = read_back(time_slot_sensor, test_source_a)
+    assert len(got) == N
+    # belief_time = event knowledge time - horizon, so a negative horizon lands after it
+    assert (got["belief_time"] - got["event_start"]).nunique() == 1

--- a/timely_beliefs/tests/test_belief_copy.py
+++ b/timely_beliefs/tests/test_belief_copy.py
@@ -88,7 +88,11 @@ def test_copy_leaves_python_side_defaults_to_the_insert(time_slot_sensor):
 
 
 def test_copy_upserts_twice_in_one_transaction(time_slot_sensor, test_source_a):
-    """The staging table outlives a batch, so it must not leak rows into the next one."""
+    """Two upserts in one transaction each get their own staging table.
+
+    The second CREATE TEMPORARY TABLE has to find the name free, and must not see the
+    first batch's rows.
+    """
     DBTimedBelief.add_to_session(
         session,
         frame_of(time_slot_sensor, test_source_a),

--- a/timely_beliefs/tests/test_belief_copy.py
+++ b/timely_beliefs/tests/test_belief_copy.py
@@ -5,6 +5,7 @@ binding one parameter per value. These tests drive batches over COPY_THRESHOLD, 
 take that path, and compare against the same beliefs written the old way.
 """
 
+import math
 from datetime import datetime, timedelta
 
 import pandas as pd
@@ -19,7 +20,7 @@ from timely_beliefs.tests import session
 N = classes.COPY_THRESHOLD + 50  # comfortably over the threshold
 
 
-def frame_of(sensor, source, n=N, offset=0.0, belief_horizon=timedelta(0)):
+def frame_of(sensor, source, n=N, offset=0.0, belief_horizon=timedelta(0), values=None):
     """A frame of `n` beliefs about consecutive events, one belief each."""
     index = pd.date_range(
         datetime(2000, 1, 3, 9, tzinfo=pytz.utc),
@@ -27,10 +28,10 @@ def frame_of(sensor, source, n=N, offset=0.0, belief_horizon=timedelta(0)):
         freq=sensor.event_resolution,
         name="event_start",
     )
+    if values is None:
+        values = [float(i) + offset for i in range(n)]
     return BeliefsDataFrame(
-        pd.Series(
-            [float(i) + offset for i in range(n)], index=index, name="event_value"
-        ),
+        pd.Series(values, index=index, name="event_value"),
         belief_horizon=belief_horizon,
         sensor=sensor,
         source=source,
@@ -131,3 +132,38 @@ def test_copy_handles_negative_and_fractional_horizons(time_slot_sensor, test_so
     assert len(got) == N
     # belief_time = event knowledge time - horizon, so a negative horizon lands after it
     assert (got["belief_time"] - got["event_start"]).nunique() == 1
+
+
+def test_copy_handles_sub_microsecond_scale_horizons(time_slot_sensor, test_source_a):
+    """A horizon under 1e-4 seconds must not be written in exponent notation.
+
+    str(timedelta.total_seconds()) renders 15 microseconds as "1.5e-05", which
+    PostgreSQL's interval parser rejects.
+    """
+    horizon = timedelta(microseconds=15)
+    DBTimedBelief.add_to_session(
+        session,
+        frame_of(time_slot_sensor, test_source_a, belief_horizon=horizon),
+        commit_transaction=True,
+    )
+    got = read_back(time_slot_sensor, test_source_a)
+    assert len(got) == N
+    assert (got["belief_time"] - got["event_start"]).nunique() == 1
+
+
+def test_copy_writes_nan_event_values_as_nan(time_slot_sensor, test_source_a):
+    """A NaN event value stays NaN, as it was under the multi-row INSERT.
+
+    An empty CSV field would be NULL, and event_value is NOT NULL.
+    """
+    values = [float(i) for i in range(N)]
+    values[3] = float("nan")
+    DBTimedBelief.add_to_session(
+        session,
+        frame_of(time_slot_sensor, test_source_a, values=values),
+        commit_transaction=True,
+    )
+    got = read_back(time_slot_sensor, test_source_a)
+    assert len(got) == N
+    assert math.isnan(got["event_value"].iloc[3])
+    assert got["event_value"].iloc[4] == 4.0

--- a/timely_beliefs/tests/test_belief_copy.py
+++ b/timely_beliefs/tests/test_belief_copy.py
@@ -43,10 +43,66 @@ def read_back(sensor, source):
     return bdf.reset_index().sort_values("event_start").reset_index(drop=True)
 
 
-def test_copy_path_is_taken(time_slot_sensor, test_source_a):
+def test_copy_path_is_taken(time_slot_sensor, test_source_a, monkeypatch):
     """A batch over the threshold goes through COPY; a small one does not."""
-    assert classes._should_copy(session, N) is True
-    assert classes._should_copy(session, classes.COPY_THRESHOLD - 1) is False
+    taken = []
+    original = DBTimedBelief._copy_to_session.__func__
+    monkeypatch.setattr(
+        DBTimedBelief,
+        "_copy_to_session",
+        classmethod(lambda cls, *args: (taken.append(True), original(cls, *args))[1]),
+    )
+
+    DBTimedBelief.add_to_session(
+        session, frame_of(time_slot_sensor, test_source_a), commit_transaction=True
+    )
+    assert taken == [True]
+
+    small = classes.COPY_THRESHOLD - 1
+    DBTimedBelief.add_to_session(
+        session,
+        frame_of(time_slot_sensor, test_source_a, n=small, offset=1000.0),
+        allow_overwrite=True,
+        commit_transaction=True,
+    )
+    assert taken == [True], "a batch under the threshold should keep the INSERT"
+
+
+def test_copy_leaves_python_side_defaults_to_the_insert(time_slot_sensor):
+    """COPY only sees the table's own DEFAULTs, so a Python-side one has to opt out.
+
+    cumulative_probability defaults to 0.5 in Python, not in the table, so a frame
+    without that column must not take the COPY path.
+    """
+    table = DBTimedBelief.__table__
+    frame = pd.DataFrame(
+        columns=["event_start", "belief_horizon", "event_value", "source_id"],
+        index=range(N),
+    )
+    assert classes._should_copy(session, table, frame) is False
+
+    frame["cumulative_probability"] = 0.5
+    assert classes._should_copy(session, table, frame) is True
+    assert classes._should_copy(session, table, frame.head(1)) is False
+
+
+def test_copy_upserts_twice_in_one_transaction(time_slot_sensor, test_source_a):
+    """The staging table outlives a batch, so it must not leak rows into the next one."""
+    DBTimedBelief.add_to_session(
+        session,
+        frame_of(time_slot_sensor, test_source_a),
+        allow_overwrite=True,
+        commit_transaction=False,
+    )
+    DBTimedBelief.add_to_session(
+        session,
+        frame_of(time_slot_sensor, test_source_a, offset=7.0),
+        allow_overwrite=True,
+        commit_transaction=True,
+    )
+    got = read_back(time_slot_sensor, test_source_a)
+    assert len(got) == N
+    assert got["event_value"].iloc[0] == 7.0
 
 
 @pytest.mark.parametrize("allow_overwrite", [False, True])

--- a/timely_beliefs/tests/test_belief_copy.py
+++ b/timely_beliefs/tests/test_belief_copy.py
@@ -11,7 +11,8 @@ from datetime import datetime, timedelta
 import pandas as pd
 import pytest
 import pytz
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError, ProgrammingError
 
 from timely_beliefs import BeliefsDataFrame, DBTimedBelief
 from timely_beliefs.beliefs import classes
@@ -223,3 +224,50 @@ def test_copy_writes_nan_event_values_as_nan(time_slot_sensor, test_source_a):
     assert len(got) == N
     assert math.isnan(got["event_value"].iloc[3])
     assert got["event_value"].iloc[4] == 4.0
+
+
+def test_copy_raises_on_duplicate_keys_within_one_upsert(
+    time_slot_sensor, test_source_a
+):
+    """Two beliefs about the same event in one allow_overwrite batch raise, as before.
+
+    ON CONFLICT DO UPDATE cannot touch a row twice, and the staging table hands it the
+    whole batch at once, so this has to fail the way the multi-row INSERT did.
+    """
+    index = pd.DatetimeIndex(
+        [datetime(2000, 1, 3, 9, tzinfo=pytz.utc)] * N, name="event_start"
+    )
+    duplicates = BeliefsDataFrame(
+        pd.Series([float(i) for i in range(N)], index=index, name="event_value"),
+        belief_horizon=timedelta(0),
+        sensor=time_slot_sensor,
+        source=test_source_a,
+    )
+    with pytest.raises(ProgrammingError) as excinfo:
+        DBTimedBelief.add_to_session(
+            session, duplicates, allow_overwrite=True, commit_transaction=True
+        )
+    assert "affect row a second time" in str(excinfo.value)
+    session.rollback()
+
+
+def test_copy_keeps_null_apart_from_the_empty_string():
+    """The NULL marker has to leave an empty string in a text column intact.
+
+    No column of a belief is text, so this drives _copy_frame against a table that has
+    one, the way a table built on the mixin might.
+    """
+    session.execute(
+        text(
+            "CREATE TEMPORARY TABLE copy_null_probe "
+            "(label text, note text) ON COMMIT DROP"
+        )
+    )
+    frame = pd.DataFrame({"label": ["", "x"], "note": [None, ""]})
+    classes._copy_frame(session, "copy_null_probe", ["label", "note"], frame)
+
+    rows = session.execute(
+        text("SELECT label, note FROM copy_null_probe ORDER BY label")
+    ).all()
+    assert rows == [("", None), ("x", "")]
+    session.rollback()

--- a/timely_beliefs/tests/test_belief_copy.py
+++ b/timely_beliefs/tests/test_belief_copy.py
@@ -195,11 +195,11 @@ def test_copy_handles_negative_and_fractional_horizons(time_slot_sensor, test_so
     assert (got["belief_time"] - got["event_start"]).nunique() == 1
 
 
-def test_copy_handles_sub_microsecond_scale_horizons(time_slot_sensor, test_source_a):
-    """A horizon under 1e-4 seconds must not be written in exponent notation.
+def test_copy_handles_microsecond_horizons(time_slot_sensor, test_source_a):
+    """A horizon of a few microseconds must not be written in exponent notation.
 
-    str(timedelta.total_seconds()) renders 15 microseconds as "1.5e-05", which
-    PostgreSQL's interval parser rejects.
+    str(timedelta.total_seconds()) switches to exponent notation below 1e-4 seconds,
+    rendering 15 microseconds as "1.5e-05", which PostgreSQL's interval parser rejects.
     """
     horizon = timedelta(microseconds=15)
     DBTimedBelief.add_to_session(


### PR DESCRIPTION
`add_to_session` compiled the whole frame into a single INSERT ... VALUES, which binds one parameter per value: a batch of 29k beliefs became roughly 175k bound parameters before the server saw anything. Most of the time went into building that statement rather than into the database.

Batches of at least COPY_THRESHOLD rows now stream through COPY on PostgreSQL. Measured on a table with the timed_belief schema and its three indexes, 29,111 rows:

  allow_overwrite=False   2,549 ms -> 232 ms   (11x)
  allow_overwrite=True    2,224 ms -> 313 ms   (7x)
  ... with every row already present, so every row conflicts:
  allow_overwrite=True    2,322 ms -> 456 ms   (5x)

Without allow_overwrite the rows go straight into the table, so a conflict raises as before. With it they land in a temporary table first and one INSERT ... SELECT carries the upsert, because COPY has no ON CONFLICT clause. Duplicate keys within a single call still raise, which is what the multi-row INSERT did too.

Two details worth knowing:

- The COPY drives the DBAPI cursor directly, so SQLAlchemy never sees a failure and a unique violation would surface as a raw psycopg error rather than as IntegrityError. It is wrapped back into SQLAlchemy's exception hierarchy, since callers catch IntegrityError.

- The upsert path costs two extra round trips per batch (create the temporary table, drop it). That is a good trade when the client and the database are close, and roughly a wash on a distant database, where the saving in statement building is offset by the extra latency. The non-upsert path needs no temporary table and wins in both cases.

Other backends and batches under the threshold keep the multi-row INSERT.

---

## Update (follow-up commits from the review)

Five commits on top of the original, each green on CI before the next. The two bullets above about the temporary table no longer describe the code — see below.

**Two regressions against the INSERT path, both with a test that fails without the fix:**

- Belief horizons were rendered with `str(total_seconds())`, whose float repr becomes exponent notation below 1e-4, so a horizon of 15 microseconds arrived as `1.5e-05 seconds` and PostgreSQL's interval parser rejected it. They are written as whole microseconds now.
- NaN was rendered as an empty field, which CSV COPY reads as NULL, so a NaN event value hit `event_value`'s NOT NULL constraint. A bound NaN used to be stored as NaN, and PostgreSQL's float input accepts `NaN`, so that is what is written.

**A larger win than the COPY itself:** `add_to_session` built an ORM object per row before it branched on `bulk_save_objects`, so the bulk path constructed tens of thousands of instances only the ORM path reads — and the sensor and source backrefs then dragged all of them through the flush. On the same 29,111-row benchmark, with the COPY already in place: **3,978 ms -> 396 ms**.

**The staging table is still created and dropped per batch,** as described above. It was briefly kept per connection instead, and that has been reverted: the reuse saved no round trip, since both shapes issue four statements per upsert batch (`CREATE` + `COPY` + `INSERT ... SELECT` + `DROP`, against `CREATE IF NOT EXISTS` + `TRUNCATE` + `COPY` + `INSERT ... SELECT`). It only avoided some catalog churn, at the price of a staging definition outliving the transaction on a pooled connection, which a migration renaming or dropping one of the columns written here would leave stale. So the "two extra round trips per batch" caveat above stands as originally written.

**Smaller things:** `_should_copy` declines a frame that omits a column with a Python-side default, since COPY only fills from the table's own DEFAULTs; NULL is written as an explicit `\N` marker so a nullable text column on a subclass can still hold an empty string; the CSV is rendered while the driver reads it rather than built into one string first; and there are now tests for duplicate keys within one `allow_overwrite` batch (`ProgrammingError`/`CardinalityViolation`, the same error the multi-row INSERT raised) and for two upserts in one transaction.

End to end, a 29k-row batch goes from 2,549 ms on `main` to about 311 ms.

Verified against a sandboxed PostgreSQL 15: timely-beliefs at 245 passed (plus the pre-existing, unrelated altair failure in `test_viz__plotting.py`), and the FlexMeasures suite at 2163 passed, 12 skipped, 4 xfailed, run against FlexMeasures `main` with this branch on the path.


